### PR TITLE
Fix auto-generating hashes

### DIFF
--- a/lib/routes/seagullApi.js
+++ b/lib/routes/seagullApi.js
@@ -195,7 +195,7 @@ module.exports = function (crudHandler, userApiClient, metrics) {
 
       function makeNewHash() {
         // generate a private pair
-        userApiClient.getAnonymousPair(req._tokendata.userid, function (err, pair) {
+        userApiClient.getAnonymousPair(function (err, pair) {
           if (err != null) {
             log.info(err, 'Unable to generate a new anonymous pair!');
             res.send(500);

--- a/test/testSeagullService.js
+++ b/test/testSeagullService.js
@@ -129,7 +129,7 @@ describe('seagull', function () {
 
     it('GET should create all required objects if they don\'t exist', function (done) {
       setupTokenAndMeta(sally);
-      sinon.stub(userApiClient, 'getAnonymousPair').callsArgWith(1, null, pair1);
+      sinon.stub(userApiClient, 'getAnonymousPair').callsArgWith(0, null, pair1);
       supertest
         .get('/sally/private/armada')
         .set(sessionTokenHeader, 'howdy')
@@ -140,14 +140,14 @@ describe('seagull', function () {
           expect(res.body).deep.equals(pair1);
           expectTokenAndMeta('howdy', sally);
           expect(userApiClient.getAnonymousPair).to.have.been.calledOnce;
-          expect(userApiClient.getAnonymousPair).to.have.been.calledWith(sally.userid, sinon.match.func);
+          expect(userApiClient.getAnonymousPair).to.have.been.calledWith(sinon.match.func);
           done();
         });
     });
 
     it('GET should create just the pair if it doesn\'t exist', function (done) {
       setupTokenAndMeta(sally);
-      sinon.stub(userApiClient, 'getAnonymousPair').callsArgWith(1, null, pair1);
+      sinon.stub(userApiClient, 'getAnonymousPair').callsArgWith(0, null, pair1);
       supertest
         .get('/sally/private/clamshell')
         .set(sessionTokenHeader, 'howdy')
@@ -158,7 +158,7 @@ describe('seagull', function () {
           expect(res.body).deep.equals(pair1);
           expectTokenAndMeta('howdy', sally);
           expect(userApiClient.getAnonymousPair).to.have.been.calledOnce;
-          expect(userApiClient.getAnonymousPair).to.have.been.calledWith(sally.userid, sinon.match.func);
+          expect(userApiClient.getAnonymousPair).to.have.been.calledWith(sinon.match.func);
           done();
         });
     });
@@ -194,7 +194,7 @@ describe('seagull', function () {
 
     it('GET should fail with a non-server token', function (done) {
       setupTokenAndMeta();
-      sinon.stub(userApiClient, 'getAnonymousPair').callsArgWith(1, null, pair1);
+      sinon.stub(userApiClient, 'getAnonymousPair').callsArgWith(0, null, pair1);
       supertest
         .get('/billy/private/armada')
         .set(sessionTokenHeader, 'howdy')


### PR DESCRIPTION
Hashes sometimes need to be generated for new users.  When this happens, seagull does some calls to do that.  Those calls weren't following the "right" method signature and that was causing havok for new users that wanted to upload data.
