### PR TITLE
Remove encryption from user metadata on read and write; update tests

### DIFF
--- a/lib/mongoCrudHandler.js
+++ b/lib/mongoCrudHandler.js
@@ -18,13 +18,8 @@
 'use strict';
 
 var _ = require('lodash');
-var crypto = require('crypto-js');
 var mongojs = require('mongojs');
 var pre = require('amoeba').pre;
-
-// define the encryption algorithm in one place
-// crypto offers many options; lacking any real preference, this seems good enough
-var encryption_algorithm = crypto.AES;
 
 // The init function takes a configuration object.
 // Config values supported are:
@@ -70,34 +65,12 @@ module.exports = function init(config) {
     ourexports._decrypt_value = _decrypt_value;
   }
 
-  function create_secret_key(pair) {
-    var hash = crypto.algo.SHA256.create();
-    hash.update(pair.hash);
-    hash.update(config.saltDeploy);
-    return hash.finalize().toString();
-  }
-
   function _encrypt_value(pair, value) {
-    var p = create_secret_key(pair);
-    var v = JSON.stringify(value);
-    var encoded = '' + encryption_algorithm.encrypt(v, p);
-    return encoded;
+    return JSON.stringify(value);
   }
 
   function _decrypt_value(pair, value) {
-    var d = encryption_algorithm.decrypt(value, create_secret_key(pair));
-    var r = null;
-    try {
-      r = d.toString(crypto.enc.Utf8);
-    } catch (e) {
-      // if the decrypt fails this will throw, so we can just return nothing and move on
-      r = null;
-    }
-    if (r) {
-      return JSON.parse(r);
-    } else {
-      return null;
-    }
+    return JSON.parse(value);
   }
 
   function _cleanupData(dataobj) {

--- a/test/testMongoCrudHandler.js
+++ b/test/testMongoCrudHandler.js
@@ -1,15 +1,15 @@
 /*
  == BSD2 LICENSE ==
  Copyright (c) 2014, Tidepool Project
- 
+
  This program is free software; you can redistribute it and/or modify it under
  the terms of the associated License, which is identical to the BSD 2-Clause
  License as published by the Open Source Initiative at opensource.org.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE. See the License for more details.
- 
+
  You should have received a copy of the License along with this program; if
  not, you can obtain one from Tidepool Project at tidepool.org.
  == BSD2 LICENSE ==
@@ -190,10 +190,11 @@ describe('metadb:', function () {
       });
     });
 
-    it('should fail to fetch if the password is bad', function (done) {
+    it('should be able to fetch even if the hash is bad as it is ignored', function (done) {
       var up = { id: userpair1.id, hash: userpair2.hash };
       metadb.getDoc(up, function (err, result) {
-        shouldFail(err, result, 401);
+        shouldSucceed(err, result, 200);
+        expect(result.detail).to.deep.equal(metatest1);
         done();
       });
     });


### PR DESCRIPTION
@jhbate This is the change to remove the encryption from the user metadata in seagull.