### PR TITLE
Allow custodian users appropriate access to custodial user metadata

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,7 @@ module.exports = function(grunt) {
       options: {
         jshintrc: '.jshintrc'
       },
-      all: ['Gruntfile.js', 'lib/**/*.js', 'test/**/*.js']
+      all: ['env.js', 'Gruntfile.js', 'lib/**/*.js', 'test/**/*.js']
     },
     docco: {
       docs: {

--- a/lib/getMetaPair.js
+++ b/lib/getMetaPair.js
@@ -17,113 +17,20 @@
 
 var _ = require('lodash');
 
-/***
-*
-* Rules:
-*
-* 1) if we are given a server token then use the userid specified
-*     i.e. req._tokendata.isserver == true
-*
-* 2) if our token is a user token then
-*
-*     a) if the token user is the same as the userid specified then continue
-*        i.e. req._tokendata.userid ===  req.params.userid
-*
-*     b) otherwise check that the token user is in req.params.userid's 'patients' or 'team' group
-*
-***/
-var checkUserPermissions = function(request, userClient, gatekeeperClient, cb){
+module.exports = function(userClient) {
 
-
-
-  var tokenUserId = request._tokendata.userid;
-  var requestedUserId = request.params.userid;
-
-  if (request._tokendata.isserver) {
-    return cb(null, requestedUserId);
-
-  } else if ( tokenUserId != requestedUserId) {
-
-    if ( request.method === 'GET'){
-      gatekeeperClient.userInGroup(tokenUserId, requestedUserId, function(err, result) {
-
-        if (!_.isEmpty(err)) {
-          return cb(err, null);
-        } else if (!_.isEmpty(result)){
-          return cb(null, requestedUserId);
-        }
-        //NOTE: the result can be empty as they are not in our team
-        //but we are in their team so lets check that scenario also
-        gatekeeperClient.userInGroup(requestedUserId, tokenUserId, function(err, result) {
-
-          if (!_.isEmpty(err)) {
-            return cb(err, null);
-          } else if (!_.isEmpty(result)){
-            return cb(null, requestedUserId);
-          } else {
-            return cb({statusCode: 401}, null);
-          }
-
-        });
-      });
-    } else {
-      //dosen't meet our rules so this is invalid
-      return cb({statusCode: 401}, null);
-    }
-  } else {
-    return cb(null, tokenUserId);
-  }
-};
-
-/*
- * prepare and return the error response when required
- **/
-var errorResponse = function(res, next, error){
-  if (error.statusCode != null) {
-    res.send(error.statusCode);
-    return next(false);
-  }
-  else {
-    res.send(500);  // internal server error -- something broke
-    return next(false);
-  }
-};
-
-/***
-  Function: getMetaPair(userClient, gatekeeperClient)
-  Desc: Middleware to retrieve the "meta" token pair -- expects _tokendata to be set on the request
-        object.  The _tokendata object must have a userid field.  The easiest way to make
-        sure that these are on the request before this middleware runs is to include the checkToken
-        middleware first.  If all goes well, attaches the _metapair variable on the request.
-  Args: userClient -- client to use when talking to the user-api
-**/
-module.exports = function(userClient, gatekeeperClient) {
   return function(req, res, next) {
-    if (req._tokendata == null) {
-      res.send(401, 'No Token');
-      return next(false);
-    }
-    checkUserPermissions(req, userClient, gatekeeperClient, function(permissionsError, userid){
-
-      if (permissionsError) {
-        return errorResponse(res,next,permissionsError);
-      } else {
-
-        userClient.getMetaPair(userid, function(metaPairError, pair) {
-
-          if (metaPairError) {
-            return errorResponse(res,next,metaPairError);
-          }
-          else if (pair == null) {
-            res.send(401, 'No metapair for you!');
-            return next(false);
-          }
-          else {
-            req._metapair = pair;
-            return next();
-          }
-        });
+    userClient.getMetaPair(req.params.userid, function(error, metapair) {
+      if (!_.isEmpty(error)) {
+        res.send(error.statusCode || 500);
+        return next(false);
+      } 
+      if (_.isEmpty(metapair)) {
+        res.send(401, 'Unauthorized');
+        return next(false);
       }
+      req._metapair = metapair;
+      return next();
     });
   };
 };

--- a/lib/routes/seagullApi.js
+++ b/lib/routes/seagullApi.js
@@ -170,10 +170,10 @@ module.exports = function (crudHandler, userApiClient, metrics) {
       function getPrivatePair(addIfNotThere) {
         crudHandler.getDoc(metaPair, function (err, mongoResult) {
           if (err) {
-            log.error(err, 'Error reading metadata doc');
             if (err.statuscode === 404 && addIfNotThere) {
               return createDocAndCallback(metaPair, res, next, function () { getPrivatePair(addIfNotThere); });
             }
+            log.error(err, 'Error reading metadata doc');
             res.send(err.statuscode);
           } else {
             var result = mongoResult.detail;

--- a/lib/seagullService.js
+++ b/lib/seagullService.js
@@ -31,15 +31,8 @@ function createServer(serverConfig, crudHandler, userApiClient, gatekeeperClient
   var userApi = require('user-api-client');
 
   var checkToken = userApi.middleware.checkToken(userApiClient);
-  var getMeta = require('./getMetaPair')(userApiClient, gatekeeperClient);
-
-  function requireServerToken(req, res, next) {
-    if (req._tokendata != null && req._tokendata.isserver) {
-      return next();
-    }
-    res.send(401, 'Insufficient Permissions');
-    return next(false);
-  }
+  var permissions = require('amoeba').permissions(gatekeeperClient);
+  var getMetaPair = require('./getMetaPair')(userApiClient);
 
   var seagullApi = require('./routes/seagullApi')(crudHandler, userApiClient, metrics);
 
@@ -50,8 +43,8 @@ function createServer(serverConfig, crudHandler, userApiClient, gatekeeperClient
   retVal.get('/collections', seagullApi.metacollections);
 
   // manage the private information
-  retVal.get('/:userid/private/:name', checkToken, requireServerToken, getMeta, seagullApi.metaprivate_read);
-  retVal.del('/:userid/private/:name', checkToken, requireServerToken, getMeta, seagullApi.metaprivate_delete);
+  retVal.get('/:userid/private/:name', checkToken, permissions.requireServer, getMetaPair, seagullApi.metaprivate_read);
+  retVal.del('/:userid/private/:name', checkToken, permissions.requireServer, getMetaPair, seagullApi.metaprivate_delete);
 
   var notImplemented = function(req, res, next) { res.send(404); next(); };
 
@@ -61,11 +54,10 @@ function createServer(serverConfig, crudHandler, userApiClient, gatekeeperClient
   retVal.del('/:userid/private', notImplemented);
 
   // manage the collections contents (at the top level)
-  retVal.post('/:userid/:collection', checkToken, getMeta, seagullApi.metacollection_update);
-  retVal.get('/:userid/:collection', checkToken, getMeta, seagullApi.metacollection_read);
-  retVal.put('/:userid/:collection', checkToken, getMeta, seagullApi.metacollection_update);
-  retVal.del('/:userid/:collection', checkToken, getMeta, seagullApi.metacollection_delete);
-
+  retVal.post('/:userid/:collection', checkToken, permissions.requireCustodian, getMetaPair, seagullApi.metacollection_update);
+  retVal.get('/:userid/:collection', checkToken, permissions.requireMembership, getMetaPair, seagullApi.metacollection_read);
+  retVal.put('/:userid/:collection', checkToken, permissions.requireCustodian, getMetaPair, seagullApi.metacollection_update);
+  retVal.del('/:userid/:collection', checkToken, permissions.requireCustodian, getMetaPair, seagullApi.metacollection_delete);
 
   retVal.on('uncaughtException', function(req, res, route, err){
     log.error(err, 'Uncaught exception on route[%s]!', route.spec ? route.spec.path : 'unknown');

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Tidepool",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "amoeba": "0.3.0",
+    "amoeba": "0.4.0-alpha.2",
     "bunyan": "1.4.0",
     "crypto-js": "3.1.2-5",
     "hakken": "0.1.8",

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,4 @@
-#! /bin/bash -eu
+#!/bin/bash -eu
+
 ./node_modules/.bin/grunt jshint
 npm test

--- a/test/testGetMetaPair.js
+++ b/test/testGetMetaPair.js
@@ -24,191 +24,61 @@ var salinity = require('salinity');
 var expect = salinity.expect;
 var sinon = salinity.sinon;
 var mockableObject = salinity.mockableObject;
-// expect violates this jshint thing a lot, so we just suppress it
-/* jshint expr: true */
 
 var userApiClient = mockableObject.make('getMetaPair');
-var gatekeeperClient = mockableObject.make('userInGroup');
-var getMeta = require('../lib/getMetaPair')(userApiClient, gatekeeperClient);
+var getMetaPair = require('../lib/getMetaPair')(userApiClient);
 
-/***
-*
-* Rules:
-*
-* 1) if we are given a server token then use the userid specified
-*     i.e. req._tokendata.isserver == true
-*
-* 2) if our token is a user token then
-*
-*     a) if the token user is the same as the userid specified then continue
-*        i.e. req._tokendata.userid ===  req.params.userid
-*
-*     b) otherwise check that the token user is in req.params.userid's 'patients' or 'team' group
-*
-***/
-describe('getMetaPair:', function () {
+describe('getMetaPair', function() {
 
   var res = mockableObject.make('send');
-  var req = {};
-  var emptyResponse = {};
+  var callback;
 
-
-  function setupStubs(response) {
-
-
-    mockableObject.reset(gatekeeperClient);
+  beforeEach(function () {
     mockableObject.reset(userApiClient);
     mockableObject.reset(res);
-
-    sinon.stub(res, 'send').returns(response);
-
-    var userInGroup = sinon.stub(gatekeeperClient, 'userInGroup');
-    userInGroup.withArgs('sally', 'bob').returns('bob');
-    userInGroup.withArgs('sally', 'sally').returns('sally');
-    userInGroup.withArgs('sally', 'other').returns('other');
-
-    var getMetaPair = sinon.stub(userApiClient, 'getMetaPair');
-
-    getMetaPair.withArgs('bob').returns('bob');
-    getMetaPair.withArgs('sally').returns('sally');
-    getMetaPair.withArgs('other').returns(false);
-  }
-
-  it('should exist', function () {
-    expect(getMeta).to.exist;
+    sinon.stub(res, 'send');
+    callback = sinon.spy();
   });
 
-
-  describe('given a no token', function () {
-    it('should return false', function () {
-      setupStubs({statusCode:401, message:'No Token'});
-
-      expect(getMeta(req,res, function(result){
-        expect(result).to.be.false;
-      }));
-
-    });
+  it('exists', function() {
+    expect(getMetaPair).to.exist;
   });
 
-  describe('given a server token', function () {
-    it('should return empty', function () {
-      setupStubs(emptyResponse);
+  it('sends response status code specified and invokes next with false', function() {
+    sinon.stub(userApiClient, 'getMetaPair').withArgs('user').callsArgWith(1, {statusCode: 400, message: 'error message'});
 
-      var req = { method:'GET', _tokendata:{ userid: 'sally', isserver: false }, params:{userid:'other'}};
-
-      expect(getMeta(req, res, function(result){
-        console.log(' ### result is', result);
-        expect(result).to.be.a('undefined');
-      }));
-
-    });
-    it('should not worry about the req.method', function () {
-      setupStubs(emptyResponse);
-
-      var req = { method:'POST', _tokendata:{ userid: 'sally', isserver: true }, params:{userid:'sally'}};
-
-      expect(getMeta(req,res, function(result){
-        expect(result).to.be.a('undefined');
-      }));
-    });
-    it('should not worry that the userid differ', function () {
-      setupStubs(emptyResponse);
-
-      var req = { method:'GET', _tokendata:{ userid: 'sally', isserver: true }, params:{userid:'bob'}};
-
-      expect(getMeta(req,res, function(result){
-        expect(result).to.be.a('undefined');
-      }));
-    });
+    getMetaPair({params: {userid: 'user'}}, res, callback);
+    expect(callback).to.have.been.calledWithExactly(false);
+    expect(res.send).to.have.been.calledWithExactly(400);
+    expect(userApiClient.getMetaPair).to.have.been.calledWithExactly('user', sinon.match.func);
   });
 
-  describe('given a user token for requested userid', function () {
-    it('should be valid when id matches', function () {
-      setupStubs(emptyResponse);
+  it('sends response status code 500 and invokes next with false', function() {
+    sinon.stub(userApiClient, 'getMetaPair').withArgs('user').callsArgWith(1, {message: 'error message'});
 
-      var req = { method:'GET', _tokendata:{ userid: 'sally', isserver: false }, params:{userid:'bob'}};
-
-      expect(getMeta(req, res, function(result){
-        expect(result).to.be.a('undefined');
-      }));
-
-    });
-    it('should be valid for PUT method', function () {
-      setupStubs(emptyResponse);
-
-      var req = { method:'PUT', _tokendata:{ userid: 'sally', isserver: false }, params:{userid:'sally'}};
-
-      expect(getMeta(req, res, function(result){
-        expect(result).to.be.a('undefined');
-      }));
-
-    });
-    it('should be valid for POST method', function () {
-      setupStubs(emptyResponse);
-
-      var req = { method:'POST', _tokendata:{ userid: 'sally', isserver: false }, params:{userid:'sally'}};
-
-      expect(getMeta(req, res, function(result){
-        console.log('Woop there it is', result);
-        expect(result).to.be.a('undefined');
-      }));
-    });
-    it('should be valid for DEL method', function () {
-      setupStubs(emptyResponse);
-
-      var req = { method:'DEL', _tokendata:{ userid: 'sally', isserver: false }, params:{userid:'sally'}};
-
-      expect(getMeta(req, res, function(result){
-        expect(result).to.be.a('undefined');
-      }));
-    });
+    getMetaPair({params: {userid: 'user'}}, res, callback);
+    expect(callback).to.have.been.calledWithExactly(false);
+    expect(res.send).to.have.been.calledWithExactly(500);
+    expect(userApiClient.getMetaPair).to.have.been.calledWithExactly('user', sinon.match.func);
   });
 
-  describe('given a user token for different userid', function () {
-    it('should invalid when not in group', function () {
-      setupStubs(emptyResponse);
+  it('sends response status code 401 Unauthorized and invokes next with false', function() {
+    sinon.stub(userApiClient, 'getMetaPair').withArgs('user').callsArgWith(1);
 
-      var req = { method:'GET', _tokendata:{ userid: 'sally', isserver: false }, params:{userid:'other'}};
+    getMetaPair({params: {userid: 'user'}}, res, callback);
+    expect(callback).to.have.been.calledWithExactly(false);
+    expect(res.send).to.have.been.calledWithExactly(401, 'Unauthorized');
+    expect(userApiClient.getMetaPair).to.have.been.calledWithExactly('user', sinon.match.func);
+  });
 
-      expect(getMeta(req,res, function(result){
-        expect(result).to.equal(false);
-      }));
-    });
-    it('should be valid when in group and GET', function () {
-      setupStubs(emptyResponse);
+  it('sets _metapair on response and succeeds', function() {
+    sinon.stub(userApiClient, 'getMetaPair').withArgs('user').callsArgWith(1, null, 'present');
 
-      var req = { method:'GET', _tokendata:{ userid: 'sally', isserver: false }, params:{userid:'other'}};
-
-      expect(getMeta(req, res, function(result){
-        expect(result).to.equal(false);
-      }));
-    });
-    it('should be invalid when in group and POST', function () {
-      setupStubs(emptyResponse);
-
-      var req = { method:'POST', _tokendata:{ userid: 'sally', isserver: false }, params:{userid:'other'}};
-
-      expect(getMeta(req, res, function(result){
-        expect(result).to.equal(false);
-      }));
-    });
-    it('should be invalid when in group and PUT', function () {
-      setupStubs(emptyResponse);
-
-      var req = { method:'PUT', _tokendata:{ userid: 'sally', isserver: false }, params:{userid:'other'}};
-
-      expect(getMeta(req, res, function(result){
-        expect(result).to.equal(false);
-      }));
-    });
-    it('should be invalid when in group and DEL', function () {
-      setupStubs(emptyResponse);
-
-      var req = { method:'DEL', _tokendata:{ userid: 'sally', isserver: false }, params:{userid:'other'}};
-
-      expect(getMeta(req, res, function(result){
-        expect(result).to.equal(false);
-      }));
-    });
+    var req = {params: {userid: 'user'}};
+    getMetaPair(req, res, callback);
+    expect(callback).to.have.been.calledWithExactly();
+    expect(res.send).to.not.have.been.called;
+    expect(req._metapair).to.equal('present');
+    expect(userApiClient.getMetaPair).to.have.been.calledWithExactly('user', sinon.match.func);
   });
 });


### PR DESCRIPTION
- Refactor getMetaPair; remove authorization into permissions functions
- Add permission.js for more granular permission checks on various APIs
- Add permission checks for custodian access
- Refactor seagullService using permission functions
- Update existing and add new unit tests for above

@jh-bate 