### PR TITLE
Add new query users API

### DIFF
--- a/lib/mongoCrudHandler.js
+++ b/lib/mongoCrudHandler.js
@@ -87,13 +87,13 @@ module.exports = function init(config) {
     db.seagull.insert({_id: pair.id, value: crypted}, {w: 1}, function (err, result) {
       if (err) {
         if (err.code == 11000) {    // this is a mongo error for duplicate key
-          done({statuscode: 400, message: 'duplicate key', detail: err}, null);
+          done({statusCode: 400, message: 'duplicate key', detail: err}, null);
         } else {
           done(err, null);
         }
       } else {
         // do we want to do something with result here?
-        done(null, {statuscode: 201, message: 'created', detail: _cleanupData(value)});
+        done(null, {statusCode: 201, message: 'created', detail: _cleanupData(value)});
       }
     });
   }
@@ -102,13 +102,13 @@ module.exports = function init(config) {
     // fetches document at pair.id, decrypts and returns it
     db.seagull.findOne({_id: pair.id}, {value: 1}, function (err, result) {
       if (err || (result === null)) {
-        done({statuscode: 404, message: 'not found', detail: err}, null);
+        done({statusCode: 404, message: 'not found', detail: err}, null);
       } else {
         var decrypted = _decrypt_value(pair, result.value);
         if (decrypted) {
-          done(null, {statuscode: 200, message: 'found', detail: decrypted});
+          done(null, {statusCode: 200, message: 'found', detail: decrypted});
         } else {
-          done({statuscode: 401, message: 'not authorized', detail: null}, null);
+          done({statusCode: 401, message: 'not authorized', detail: null}, null);
         }
       }
     });
@@ -120,9 +120,9 @@ module.exports = function init(config) {
     var crypted = _encrypt_value(pair, value);
     db.seagull.update({_id: pair.id}, {value: crypted}, {w: 1}, function (err, result) {
       if (err) {
-        done({statuscode: 500, message: 'server error', detail: err}, null);
+        done({statusCode: 500, message: 'server error', detail: err}, null);
       } else {
-        done(null, {statuscode: 200, message: 'created', detail: value});
+        done(null, {statusCode: 200, message: 'created', detail: value});
       }
     });
   }
@@ -200,7 +200,7 @@ module.exports = function init(config) {
 
   function serverStatus(done) {
     _status.running = (_status.deps.down.length === 0);
-    _status.statuscode = _status.running ? 200 : 500;
+    _status.statusCode = _status.running ? 200 : 500;
     done(null, _status);
   }
 

--- a/lib/routes/seagullApi.js
+++ b/lib/routes/seagullApi.js
@@ -56,9 +56,13 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
   function parseUsersQuery(req) {
     var query = {};
 
-    var permissions = _.trim(req.params.permissions);
-    if (permissions !== '') {
-      query.permissions = _.compact(_.map(permissions.split(','), _.trim));
+    var trustorPermissions = _.trim(req.params.trustorPermissions);
+    if (trustorPermissions !== '') {
+      query.trustorPermissions = _.compact(_.map(trustorPermissions.split(','), _.trim));
+    }
+    var trusteePermissions = _.trim(req.params.trusteePermissions);
+    if (trusteePermissions !== '') {
+      query.trusteePermissions = _.compact(_.map(trusteePermissions.split(','), _.trim));
     }
     var email = _.trim(req.params.email);
     if (email !== '') {
@@ -90,7 +94,10 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
 
   function userMatchesQueryOnPermissions(user, query) {
     if (query) {
-      if (_.has(query, 'permissions') && !_.every(query.permissions, _.partial(_.has, user.permissions))) {
+      if (_.has(query, 'trustorPermissions') && !_.every(query.trustorPermissions, _.partial(_.has, user.trustorPermissions))) {
+        return false;
+      }
+      if (_.has(query, 'trusteePermissions') && !_.every(query.trusteePermissions, _.partial(_.has, user.trusteePermissions))) {
         return false;
       }
     }
@@ -163,94 +170,102 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
      */
 
     users: function(req, res, next) {
-      var userId = _.trim(req.params.userid);
-      if (userId === '') {
-        res.send(400, 'User id not specified');
+      var targetUserId = _.trim(req.params.userid);
+      if (targetUserId === '') {
+        res.send(400, 'Target user id not specified');
         return next();
       }
 
       var query = parseUsersQuery(req);
 
-      gatekeeperClient.groupsForUser(userId, function(error, usersPermissions) {
+      var mergedUserPermissions = {};
+      gatekeeperClient.groupsForUser(targetUserId, function(error, trustorUserPermissions) {
         if (error) {
-          log.error(error, 'Error getting permissions for user id', userId);
+          log.error(error, 'Error getting groups for target user id', targetUserId);
           res.send(error.statusCode || 500);
           return next(false);
         }
 
-        async.mapLimit(_.keys(usersPermissions), 5, function(sharedUserId, callback) {
-          if (sharedUserId == userId) {
-            return async.setImmediate(function() {
-              return callback();
-            });
-          }
+        _.forEach(trustorUserPermissions, function(p, u) { mergedUserPermissions[u] = { trustorPermissions: p }; });
 
-          var sharedPermissions = usersPermissions[sharedUserId];
-
-          if (!userMatchesQueryOnPermissions({permissions: sharedPermissions}, query)) {
-            return callback();
-          }
-
-          userApiClient.getUserInfo(sharedUserId, function(error, user) {
-            if (error) {
-              log.error(error, 'Error getting user for user id', userId);
-              return callback(error);
-            } else if (!user) {
-              log.error('No user returned for user id', userId);
-              return callback({statusCode: 500});
-            }
-
-            if (!userMatchesQueryOnUser(user, query)) {
-              return callback();
-            }
-
-            user.permissions = sharedPermissions;
-
-            userApiClient.getMetaPair(sharedUserId, function(error, metaPair) {
-              if (error) {
-                if (error.statusCode == 404) {
-                  return callback(null, userMatchingQuery(user, query));
-                }
-                log.error(error, 'Error getting meta pair for user id', sharedUserId);
-                return callback(error);
-              } else if (!metaPair) {
-                return callback(null, userMatchingQuery(user, query));
-              }
-
-              crudHandler.getDoc(metaPair, function(error, document) {
-                if (error) {
-                  if (error.statusCode == 404) {
-                    return callback(null, userMatchingQuery(user, query));
-                  }
-                  log.error(error, 'Error getting document for meta pair', metaPair);
-                  return callback(error);
-                }
-
-                user.profile = _.result(document, 'detail.profile');
-
-                return callback(null, userMatchingQuery(user, query));
-              });
-            });
-          });
-        }, function(error, users) {
-          if (req._tokendata.isserver) {
-            metrics.postServer('query users', {params: req.params, error: error}, req._sessionToken, function(){});
-          } else {
-            metrics.postThisUser('query users', {params: req.params, error: error}, req._sessionToken, function(){});
-          }
-
+        gatekeeperClient.usersInGroup(targetUserId, function(error, trusteeUserPermissions) {
           if (error) {
+            log.error(error, 'Error getting users for target user id', targetUserId);
             res.send(error.statusCode || 500);
             return next(false);
           }
 
-          users = _.compact(users);
-          if (!req._tokendata.isserver) {
-            users = _.map(users, sanitizeUser);
-          }
+          _.forEach(trusteeUserPermissions, function(p, u) { mergedUserPermissions[u] = _.merge(mergedUserPermissions[u] || {}, { trusteePermissions: p }); });
 
-          res.send(200, users);
-          return next();
+          delete mergedUserPermissions[targetUserId];
+          mergedUserPermissions = _.pick(mergedUserPermissions, function(p) { return userMatchesQueryOnPermissions(p, query); });
+
+          async.mapLimit(_.keys(mergedUserPermissions), 5, function(trustorUserId, callback) {
+            userApiClient.getUserInfo(trustorUserId, function(error, user) {
+              if (error) {
+                log.error(error, 'Error getting user for user id', trustorUserId);
+                return callback(error);
+              } else if (!user) {
+                log.error('No user returned for user id', trustorUserId);
+                return callback({statusCode: 500});
+              }
+
+              if (!userMatchesQueryOnUser(user, query)) {
+                return callback();
+              }
+
+              user = _.merge(user, mergedUserPermissions[trustorUserId]);
+
+              userApiClient.getMetaPair(trustorUserId, function(error, metaPair) {
+                if (error) {
+                  if (error.statusCode == 404) {
+                    return callback(null, userMatchingQuery(user, query));
+                  }
+                  log.error(error, 'Error getting meta pair for user id', trustorUserId);
+                  return callback(error);
+                } else if (!metaPair) {
+                  return callback(null, userMatchingQuery(user, query));
+                }
+
+                crudHandler.getDoc(metaPair, function(error, document) {
+                  if (error) {
+                    if (error.statusCode == 404) {
+                      return callback(null, userMatchingQuery(user, query));
+                    }
+                    log.error(error, 'Error getting document for meta pair', metaPair);
+                    return callback(error);
+                  }
+
+                  user.profile = _.result(document, 'detail.profile');
+
+                  if (_.isEmpty(user.trustorPermissions)) {
+                    delete user.profile.patient;
+                  }
+
+                  return callback(null, userMatchingQuery(user, query));
+                });
+              });
+            });
+          }, function(error, users) {
+            if (req._tokendata.isserver) {
+              metrics.postServer('query users', {params: req.params, error: error}, req._sessionToken, function(){});
+            } else {
+              metrics.postThisUser('query users', {params: req.params, error: error}, req._sessionToken, function(){});
+            }
+
+            if (error) {
+              res.send(error.statusCode || 500);
+              return next(false);
+            }
+
+            users = _.compact(users);
+            if (!req._tokendata.isserver) {
+              users = _.map(users, sanitizeUser);
+            }
+
+            res.send(200, users);
+            return next();
+          });
         });
       });
     },

--- a/lib/routes/seagullApi.js
+++ b/lib/routes/seagullApi.js
@@ -20,13 +20,14 @@
 var util = require('util');
 
 var _ = require('lodash');
+var async = require('async');
 
 var log = require('../log.js')('seagullApi.js');
 
 /*
  Http interface for group-api
  */
-module.exports = function (crudHandler, userApiClient, metrics) {
+module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics) {
 
   /*
    HELPERS
@@ -48,6 +49,99 @@ module.exports = function (crudHandler, userApiClient, metrics) {
     });
   }
 
+  function stringToBoolean(value) {
+    return _.includes(['true', 'yes', 'y', '1'], _.trim(value).toLowerCase());
+  }
+
+  function parseUsersQuery(req) {
+    var query = {};
+
+    var permissions = _.trim(req.params.permissions);
+    if (permissions !== '') {
+      query.permissions = _.compact(_.map(permissions.split(','), _.trim));
+    }
+    var email = _.trim(req.params.email);
+    if (email !== '') {
+      query.email = new RegExp(_.escapeRegExp(email), 'i');
+    }
+    var emailVerified = _.trim(req.params.emailVerified);
+    if (emailVerified !== '') {
+      query.emailVerified = stringToBoolean(emailVerified);
+    }
+    var termsAccepted = _.trim(req.params.termsAccepted);
+    if (termsAccepted !== '') {
+      query.termsAccepted = new RegExp(_.escapeRegExp(termsAccepted), 'i');
+    }
+    var name = _.trim(req.params.name);
+    if (name !== '') {
+      query.name = new RegExp(_.escapeRegExp(name), 'i');
+    }
+    var birthday = _.trim(req.params.birthday);
+    if (birthday !== '') {
+      query.birthday = new RegExp(_.escapeRegExp(birthday), 'i');
+    }
+    var diagnosisDate = _.trim(req.params.diagnosisDate);
+    if (diagnosisDate !== '') {
+      query.diagnosisDate = new RegExp(_.escapeRegExp(diagnosisDate), 'i');
+    }
+
+    return _.isEmpty(query) ? null : query;
+  }
+
+  function userMatchesQueryOnPermissions(user, query) {
+    if (query) {
+      if (_.has(query, 'permissions') && !_.every(query.permissions, _.partial(_.has, user.permissions))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function userMatchesQueryOnUser(user, query) {
+    if (query) {
+      if (_.has(query, 'email') && !query.email.test(user.username)) {
+        return false;
+      }
+      if (_.has(query, 'emailVerified') && query.emailVerified != stringToBoolean(user.emailVerified)) {
+        return false;
+      }
+      if (_.has(query, 'termsAccepted') && !query.termsAccepted.test(user.termsAccepted)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function userMatchesQueryOnProfile(user, query) {
+    if (query) {
+      if (_.has(query, 'name') && !query.name.test(_.result(user, 'profile.fullName'))) {
+        return false;
+      }
+      if (_.has(query, 'birthday') && !query.birthday.test(_.result(user, 'profile.patient.birthday'))) {
+        return false;
+      }
+      if (_.has(query, 'diagnosisDate') && !query.diagnosisDate.test(_.result(user, 'profile.patient.diagnosisDate'))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function userMatchingQuery(user, query) {
+    if (query) {
+      if (!userMatchesQueryOnPermissions(user, query) ||
+          !userMatchesQueryOnUser(user, query) ||
+          !userMatchesQueryOnProfile(user, query)) {
+        return null;
+      }
+    }
+    return user;
+  }
+
+  function sanitizeUser(user) {
+    return _.omit(user, 'passwordExists');
+  }
+
   return {
     /** HEALTH CHECK **/
     status: function (req, res, next) {
@@ -67,6 +161,99 @@ module.exports = function (crudHandler, userApiClient, metrics) {
     /*
      IMPLEMENTATIONS OF METHODS
      */
+
+    users: function(req, res, next) {
+      var userId = _.trim(req.params.userid);
+      if (userId === '') {
+        res.send(400, 'User id not specified');
+        return next();
+      }
+
+      var query = parseUsersQuery(req);
+
+      gatekeeperClient.groupsForUser(userId, function(error, usersPermissions) {
+        if (error) {
+          log.error(error, 'Error getting permissions for user id', userId);
+          res.send(error.statusCode || 500);
+          return next(false);
+        }
+
+        async.mapLimit(_.keys(usersPermissions), 5, function(sharedUserId, callback) {
+          if (sharedUserId == userId) {
+            return async.setImmediate(function() {
+              return callback();
+            });
+          }
+
+          var sharedPermissions = usersPermissions[sharedUserId];
+
+          if (!userMatchesQueryOnPermissions({permissions: sharedPermissions}, query)) {
+            return callback();
+          }
+
+          userApiClient.getUserInfo(sharedUserId, function(error, user) {
+            if (error) {
+              log.error(error, 'Error getting user for user id', userId);
+              return callback(error);
+            } else if (!user) {
+              log.error('No user returned for user id', userId);
+              return callback({statusCode: 500});
+            }
+
+            if (!userMatchesQueryOnUser(user, query)) {
+              return callback();
+            }
+
+            user.permissions = sharedPermissions;
+
+            userApiClient.getMetaPair(sharedUserId, function(error, metaPair) {
+              if (error) {
+                if (error.statusCode == 404) {
+                  return callback(null, userMatchingQuery(user, query));
+                }
+                log.error(error, 'Error getting meta pair for user id', sharedUserId);
+                return callback(error);
+              } else if (!metaPair) {
+                return callback(null, userMatchingQuery(user, query));
+              }
+
+              crudHandler.getDoc(metaPair, function(error, document) {
+                if (error) {
+                  if (error.statusCode == 404) {
+                    return callback(null, userMatchingQuery(user, query));
+                  }
+                  log.error(error, 'Error getting document for meta pair', metaPair);
+                  return callback(error);
+                }
+
+                user.profile = _.result(document, 'detail.profile');
+
+                return callback(null, userMatchingQuery(user, query));
+              });
+            });
+          });
+        }, function(error, users) {
+          if (req._tokendata.isserver) {
+            metrics.postServer('query users', {params: req.params, error: error}, req._sessionToken, function(){});
+          } else {
+            metrics.postThisUser('query users', {params: req.params, error: error}, req._sessionToken, function(){});
+          }
+
+          if (error) {
+            res.send(error.statusCode || 500);
+            return next(false);
+          }
+
+          users = _.compact(users);
+          if (!req._tokendata.isserver) {
+            users = _.map(users, sanitizeUser);
+          }
+
+          res.send(200, users);
+          return next();
+        });
+      });
+    },
 
     metacollections: function (req, res, next) {
       log.debug('metacollections: params[%j], url[%s], method[%s]', req.params, req.url, req.method);

--- a/lib/routes/seagullApi.js
+++ b/lib/routes/seagullApi.js
@@ -36,10 +36,10 @@ module.exports = function (crudHandler, userApiClient, metrics) {
     crudHandler.createDoc(metaPair, {}, function (err, result) {
       if (err) {
         log.error(err, 'Error creating metadata doc');
-        if (err.statuscode == 400) {
+        if (err.statusCode == 400) {
           res.send(422);
         } else {
-          res.send(err.statuscode);
+          res.send(err.statusCode);
         }
         return next();
       } else {
@@ -57,8 +57,8 @@ module.exports = function (crudHandler, userApiClient, metrics) {
         res.send(parseInt(req.params.status));
       } else {
         crudHandler.status(function (error, result) {
-          log.debug('returning status ' + result.statuscode);
-          res.send(result.statuscode, result.deps);
+          log.debug('returning status ' + result.statusCode);
+          res.send(result.statusCode, result.deps);
         });
       }
       return next();
@@ -89,7 +89,7 @@ module.exports = function (crudHandler, userApiClient, metrics) {
       crudHandler.getDoc(req._metapair, function (err, result) {
         if (err) {
           log.error(err, 'Error reading metadata doc');
-          res.send(err.statuscode);
+          res.send(err.statusCode);
         } else {
           var retVal = result.detail[collection];
           if (retVal == null) {
@@ -129,11 +129,11 @@ module.exports = function (crudHandler, userApiClient, metrics) {
         var metaPair = req._metapair;
         crudHandler.partialUpdate(metaPair, updates, function (err, result) {
           if (err) {
-            if (err.statuscode == 404 && addIfNotThere) {
+            if (err.statusCode == 404 && addIfNotThere) {
               return createDocAndCallback(metaPair, res, next, function () { doUpdate(false); });
             } else {
               log.error(err, 'Error updating metadata doc');
-              res.send(err.statuscode);
+              res.send(err.statusCode);
               return next();
             }
           } else {
@@ -170,11 +170,11 @@ module.exports = function (crudHandler, userApiClient, metrics) {
       function getPrivatePair(addIfNotThere) {
         crudHandler.getDoc(metaPair, function (err, mongoResult) {
           if (err) {
-            if (err.statuscode === 404 && addIfNotThere) {
+            if (err.statusCode === 404 && addIfNotThere) {
               return createDocAndCallback(metaPair, res, next, function () { getPrivatePair(addIfNotThere); });
             }
             log.error(err, 'Error reading metadata doc');
-            res.send(err.statuscode);
+            res.send(err.statusCode);
           } else {
             var result = mongoResult.detail;
             // we have the doc now, let's see if it has the name
@@ -207,11 +207,11 @@ module.exports = function (crudHandler, userApiClient, metrics) {
             crudHandler.partialUpdate(req._metapair, update, function (err, result) {
               if (err) {
                 log.error(err, 'Error creating metadata doc');
-                if (err.statuscode == 404) {
+                if (err.statusCode == 404) {
                   res.send(404);
                   return next();
                 } else {
-                  res.send(err.statuscode);
+                  res.send(err.statusCode);
                   return next();
                 }
               } else {

--- a/lib/routes/seagullApi.js
+++ b/lib/routes/seagullApi.js
@@ -49,20 +49,58 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
     });
   }
 
+  var ANY = ['any'];
+  var NONE = ['none'];
+  var TRUES = ['true', 'yes', 'y', '1'];
+
+  function parsePermissions(permissions) {
+    permissions = _.trim(permissions);
+    if (permissions !== '') {
+      permissions = _.compact(_.map(permissions.split(','), _.trim));
+      if (_.isEqual(permissions, ANY)) {
+        return ANY;
+      } else if (_.isEqual(permissions, NONE)) {
+        return NONE;
+      } else if (!_.isEmpty(permissions)) {
+        return permissions;
+      }
+    }
+    return null;
+  }
+
+  function arePermissionsValid(permissions) {
+    if (permissions.length > 1) {
+      if (!_.isEmpty(_.intersection(_.union(ANY, NONE), permissions))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function arePermissionsSatisfied(queryPermissions, userPermissions) {
+    if (queryPermissions === ANY) {
+      return !_.isEmpty(userPermissions);
+    } else if (queryPermissions === NONE) {
+      return _.isEmpty(userPermissions);
+    } else {
+      return _.every(queryPermissions, _.partial(_.has, userPermissions));
+    }
+  }
+
   function stringToBoolean(value) {
-    return _.includes(['true', 'yes', 'y', '1'], _.trim(value).toLowerCase());
+    return _.includes(TRUES, _.trim(value).toLowerCase());
   }
 
   function parseUsersQuery(req) {
     var query = {};
 
-    var trustorPermissions = _.trim(req.params.trustorPermissions);
-    if (trustorPermissions !== '') {
-      query.trustorPermissions = _.compact(_.map(trustorPermissions.split(','), _.trim));
+    var trustorPermissions = parsePermissions(req.params.trustorPermissions);
+    if (trustorPermissions) {
+      query.trustorPermissions = trustorPermissions;
     }
-    var trusteePermissions = _.trim(req.params.trusteePermissions);
-    if (trusteePermissions !== '') {
-      query.trusteePermissions = _.compact(_.map(trusteePermissions.split(','), _.trim));
+    var trusteePermissions = parsePermissions(req.params.trusteePermissions);
+    if (trusteePermissions) {
+      query.trusteePermissions = trusteePermissions;
     }
     var email = _.trim(req.params.email);
     if (email !== '') {
@@ -92,12 +130,24 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
     return _.isEmpty(query) ? null : query;
   }
 
-  function userMatchesQueryOnPermissions(user, query) {
+  function isUsersQueryValid(query) {
     if (query) {
-      if (_.has(query, 'trustorPermissions') && !_.every(query.trustorPermissions, _.partial(_.has, user.trustorPermissions))) {
+      if (_.has(query, 'trustorPermissions') && !arePermissionsValid(query.trustorPermissions)) {
         return false;
       }
-      if (_.has(query, 'trusteePermissions') && !_.every(query.trusteePermissions, _.partial(_.has, user.trusteePermissions))) {
+      if (_.has(query, 'trusteePermissions') && !arePermissionsValid(query.trusteePermissions)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function userMatchesQueryOnPermissions(user, query) {
+    if (query) {
+      if (_.has(query, 'trustorPermissions') && !arePermissionsSatisfied(query.trustorPermissions, user.trustorPermissions)) {
+        return false;
+      }
+      if (_.has(query, 'trusteePermissions') && !arePermissionsSatisfied(query.trusteePermissions, user.trusteePermissions)) {
         return false;
       }
     }
@@ -172,11 +222,17 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
     users: function(req, res, next) {
       var targetUserId = _.trim(req.params.userid);
       if (targetUserId === '') {
+        log.error('Target user id not specified');
         res.send(400, 'Target user id not specified');
-        return next();
+        return next(false);
       }
 
       var query = parseUsersQuery(req);
+      if (!isUsersQueryValid(query)) {
+        log.error('Query is invalid', query);
+        res.send(400, 'Query is invalid');
+        return next(false);
+      }
 
       var mergedUserPermissions = {};
       gatekeeperClient.groupsForUser(targetUserId, function(error, trustorUserPermissions) {

--- a/lib/seagullService.js
+++ b/lib/seagullService.js
@@ -1,15 +1,15 @@
 /*
  == BSD2 LICENSE ==
  Copyright (c) 2014, Tidepool Project
- 
+
  This program is free software; you can redistribute it and/or modify it under
  the terms of the associated License, which is identical to the BSD 2-Clause
  License as published by the Open Source Initiative at opensource.org.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE. See the License for more details.
- 
+
  You should have received a copy of the License along with this program; if
  not, you can obtain one from Tidepool Project at tidepool.org.
  == BSD2 LICENSE ==
@@ -34,10 +34,13 @@ function createServer(serverConfig, crudHandler, userApiClient, gatekeeperClient
   var permissions = require('amoeba').permissions(gatekeeperClient);
   var getMetaPair = require('./getMetaPair')(userApiClient);
 
-  var seagullApi = require('./routes/seagullApi')(crudHandler, userApiClient, metrics);
+  var seagullApi = require('./routes/seagullApi')(crudHandler, userApiClient, gatekeeperClient, metrics);
 
   //health check
   retVal.get('/status', seagullApi.status);
+
+  // unified users
+  retVal.get('/users/:userid/users', checkToken, permissions.requireCustodian, seagullApi.users);
 
   // get the valid collections
   retVal.get('/collections', seagullApi.metacollections);

--- a/package.json
+++ b/package.json
@@ -15,10 +15,11 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "amoeba": "0.4.0-alpha.2",
+    "async": "0.9.0",
     "bunyan": "1.4.0",
     "crypto-js": "3.1.2-5",
     "hakken": "0.1.8",
-    "lodash": "3.4.0",
+    "lodash": "3.10.1",
     "mongojs": "0.18.2",
     "request": "2.67.0",
     "restify": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seagull",
-  "version": "0.2.4",
+  "version": "0.7.0-alpha.1",
   "description": "API for managing user metadata.",
   "main": "lib/index.js",
   "directories": {

--- a/test/testMongoCrudHandler.js
+++ b/test/testMongoCrudHandler.js
@@ -43,15 +43,15 @@ function shouldSucceed(err, result, code) {
   }
   expect(err).to.not.exist;
   expect(result).to.exist;
-  expect(result.statuscode).to.equal(code);
+  expect(result.statusCode).to.equal(code);
 }
 
 function shouldFail(err, result, code) {
   if (result) {
     console.log('Got result when expecting null', result);
   }
-  expect(err).to.have.property('statuscode');
-  expect(err.statuscode).to.equal(code);
+  expect(err).to.have.property('statusCode');
+  expect(err.statusCode).to.equal(code);
   expect(result).to.not.exist;
   expect(err).to.exist;
   expect(err.message).to.exist;

--- a/test/testSeagullServiceUsers.js
+++ b/test/testSeagullServiceUsers.js
@@ -1,0 +1,550 @@
+/*
+ == BSD2 LICENSE ==
+ Copyright (c) 2014, Tidepool Project
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the associated License, which is identical to the BSD 2-Clause
+ License as published by the Open Source Initiative at opensource.org.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the License for more details.
+
+ You should have received a copy of the License along with this program; if
+ not, you can obtain one from Tidepool Project at tidepool.org.
+ == BSD2 LICENSE ==
+ */
+
+// expect violates this jshint thing a lot, so we just suppress it
+/* jshint expr: true */
+
+'use strict';
+
+var _ = require('lodash');
+var salinity = require('salinity');
+
+var expect = salinity.expect;
+var mockableObject = salinity.mockableObject;
+var sinon = salinity.sinon;
+
+var env = {
+  httpPort: 21000,
+};
+
+var mockCrudHandler = mockableObject.make('getDoc');
+var mockUserApiClient = mockableObject.make('checkToken', 'getMetaPair', 'getAnonymousPair', 'getUserInfo');
+var mockGatekeeperClient = mockableObject.make('userInGroup', 'groupsForUser');
+var mockMetrics = mockableObject.make('postServer', 'postThisUser', 'postWithUser');
+
+var seagull = require('../lib/seagullService.js')(env, mockCrudHandler, mockUserApiClient, mockGatekeeperClient, mockMetrics);
+var supertest = require('supertest')('http://localhost:' + env.httpPort);
+
+describe('seagull/users', function () {
+
+  before(function(done) {
+    seagull.start(done);
+  });
+
+  after(function() {
+    seagull.close();
+  });
+
+  beforeEach(function() {
+    mockableObject.reset(mockCrudHandler);
+    mockableObject.reset(mockUserApiClient);
+    mockableObject.reset(mockGatekeeperClient);
+    mockableObject.reset(mockMetrics);
+  });
+
+  describe('GET /users/:userid/users', function(done) {
+
+    var alphaUser, alphaMetaPair, alphaProfile, alphaPermissions, alphaDoc, alphaFinal;
+    var bravoUser, bravoMetaPair, bravoProfile, bravoPermissions, bravoDoc, bravoFinal;
+    var targetUser, custodianUser;
+    var serverToken, targetToken, custodianToken, viewerToken;
+
+    var sessionTokenId;
+    var targetUrl;
+
+    function setupData() {
+      alphaUser = { userid: 'alpha', username: 'alpha@tidepool.org', emailVerified: true, termsAccepted: '2016-01-01T12:00:00-07:00', passwordExists: true };
+      alphaMetaPair = { id: 'alpha-metapair-id', hash: 'alpha-metapair-hash' };
+      alphaProfile = { fullName: 'Alpha', patient: { birthday: '2001-11-30', diagnosisDate: '2010-12-31' } };
+      alphaPermissions = { upload: {}, view: {} };
+      alphaDoc = { detail: { profile: alphaProfile } };
+      alphaFinal = _.merge({}, alphaUser, { profile: alphaProfile, permissions: alphaPermissions });
+
+      bravoUser = { userid: 'bravo', username: 'bravo@tidepool.org', emailVerified: false, termsAccepted: '2015-12-31T23:59:59-08:00', passwordExists: true };
+      bravoMetaPair = { id: 'bravo-metapair-id', hash: 'bravo-metapair-hash' };
+      bravoProfile = { fullName: 'Bravo', patient: { birthday: '1970-01-30', diagnosisDate: '1990-02-31' } };
+      bravoPermissions = { view: {} };
+      bravoDoc = { detail: { profile: bravoProfile } };
+      bravoFinal = _.merge({}, bravoUser, { profile: bravoProfile, permissions: bravoPermissions });
+
+      targetUser = { userid: 'target', groups: {} };
+      targetUser.groups[alphaUser.userid] = alphaPermissions;
+      targetUser.groups[bravoUser.userid] = bravoPermissions;
+
+      custodianUser = { userid: 'custodian', permissions: { custodian: {} } };
+
+      serverToken = { userid: 'server', isserver: true };
+      targetToken = { userid: targetUser.userid, isserver: false };
+      custodianToken = { userid: custodianUser.userid, isserver: false };
+      viewerToken = { userid: 'stranger', isserver: false };
+
+      sessionTokenId = targetToken.userid;
+
+      targetUrl = '/users/' + targetUser.userid + '/users';
+    }
+
+    var getDocStub, checkTokenStub, getUserInfoStub, getMetaPairStub, userInGroupStub, groupsForUserStub;
+
+    function setupStubs() {
+      getDocStub = sinon.stub(mockCrudHandler, 'getDoc');
+      checkTokenStub = sinon.stub(mockUserApiClient, 'checkToken');
+      getUserInfoStub = sinon.stub(mockUserApiClient, 'getUserInfo');
+      getMetaPairStub = sinon.stub(mockUserApiClient, 'getMetaPair');
+      userInGroupStub = sinon.stub(mockGatekeeperClient, 'userInGroup');
+      groupsForUserStub = sinon.stub(mockGatekeeperClient, 'groupsForUser');
+
+      checkTokenStub.withArgs(serverToken.userid).callsArgWith(1, null, serverToken);
+      checkTokenStub.withArgs(targetToken.userid).callsArgWith(1, null, targetToken);
+      checkTokenStub.withArgs(custodianToken.userid).callsArgWith(1, null, custodianToken);
+      checkTokenStub.withArgs(viewerToken.userid).callsArgWith(1, null, viewerToken);
+      checkTokenStub.callsArgWith(1, {statusCode: 401}, null);
+      userInGroupStub.withArgs(custodianToken.userid, targetUser.userid).callsArgWith(2, null, { custodian: {} });
+      userInGroupStub.withArgs(viewerToken.userid, targetUser.userid).callsArgWith(2, null, { view: {} });
+      groupsForUserStub.withArgs(targetUser.userid).callsArgWith(1, null, targetUser.groups);
+      getUserInfoStub.withArgs(alphaUser.userid).callsArgWith(1, null, alphaUser);
+      getUserInfoStub.withArgs(bravoUser.userid).callsArgWith(1, null, bravoUser);
+      getMetaPairStub.withArgs(alphaUser.userid).callsArgWith(1, null, alphaMetaPair);
+      getMetaPairStub.withArgs(bravoUser.userid).callsArgWith(1, null, bravoMetaPair);
+      getDocStub.withArgs(alphaMetaPair).callsArgWith(1, null, alphaDoc);
+      getDocStub.withArgs(bravoMetaPair).callsArgWith(1, null, bravoDoc);
+
+      sinon.stub(mockMetrics, 'postServer').callsArg(3);
+      sinon.stub(mockMetrics, 'postThisUser').callsArg(3);
+   }
+
+    beforeEach(function() {
+      setupData();
+      setupStubs();
+    });
+
+    function sanitizeUsers() {
+      if (sessionTokenId !== serverToken.userid) {
+        alphaFinal = _.omit(alphaFinal, 'passwordExists');
+        bravoFinal = _.omit(bravoFinal, 'passwordExists');
+      }
+    }
+
+    function test(url, statusCode, expectations, done) {
+      supertest
+        .get(url)
+        .set('x-tidepool-session-token', sessionTokenId)
+        .expect(statusCode)
+        .end(function(err, res) {
+          _.forEach(expectations, function(expectation) {
+            expectation(err, res);
+          });
+          done(err);
+        });
+    }
+
+    function expectSuccessfulTest(url, expectations, done) {
+      return test(url, 200, _.flatten([expectNoError, expectations]), done);
+    }
+
+    function expectUnauthorizedTest(url, expectations, done) {
+      return test(url, 401, _.flatten([expectNoError, expectations]), done);
+    }
+
+    function expectNoError(err, res) {
+      expect(err).to.not.exist;
+    }
+
+    function expectBodyWithEmptyObject(err, res) {
+      expect(res.body).deep.equals({});
+    }
+
+    function expectBodyWithEmptyArray(err, res) {
+      expect(res.body).deep.equals([]);
+    }
+
+    function expectBodyWithAlpha(err, res) {
+      sanitizeUsers();
+      expect(res.body).deep.equals([alphaFinal]);
+    }
+
+    function expectBodyWithBravo(err, res) {
+      sanitizeUsers();
+      expect(res.body).deep.equals([bravoFinal]);
+    }
+
+    function expectBodyWithAlphaAndBravo(err, res) {
+      sanitizeUsers();
+      expect(res.body).deep.equals([alphaFinal, bravoFinal]);
+    }
+
+    function expectCheckToken() {
+      expect(mockUserApiClient.checkToken).to.have.been.calledOnce;
+      expect(mockUserApiClient.checkToken).to.have.been.calledWithExactly(sessionTokenId, sinon.match.func);
+    }
+
+    function expectUserInGroupNotCalled() {
+      expect(mockGatekeeperClient.userInGroup).to.not.have.been.called;
+    }
+
+    function expectUserInGroup() {
+      expectCheckToken();
+      expect(mockGatekeeperClient.userInGroup).to.have.been.calledOnce;
+      expect(mockGatekeeperClient.userInGroup).to.have.been.calledWithExactly(sinon.match.string, targetUser.userid, sinon.match.func);
+    }
+
+    function expectGroupsForUserNotCalled() {
+      expect(mockGatekeeperClient.groupsForUser).to.not.have.been.called;
+    }
+
+    function expectGroupsForUser() {
+      expectCheckToken();
+      expect(mockGatekeeperClient.groupsForUser).to.have.been.calledOnce;
+      expect(mockGatekeeperClient.groupsForUser).to.have.been.calledWithExactly(targetUser.userid, sinon.match.func);
+    }
+
+    function expectGetUserInfoNotCalled() {
+      expect(mockUserApiClient.getUserInfo).to.not.have.been.called;
+    }
+
+    function expectGetUserInfoForAlpha() {
+      expect(mockUserApiClient.getUserInfo).to.have.been.calledOnce;
+      expect(mockUserApiClient.getUserInfo).to.have.been.calledWithExactly(alphaUser.userid, sinon.match.func);
+    }
+
+    function expectGetUserInfoForAlphaAndBravo() {
+      expectGroupsForUser();
+      expect(mockUserApiClient.getUserInfo).to.have.been.calledTwice;
+      expect(mockUserApiClient.getUserInfo.firstCall).to.have.been.calledWithExactly(alphaUser.userid, sinon.match.func);
+      expect(mockUserApiClient.getUserInfo.secondCall).to.have.been.calledWithExactly(bravoUser.userid, sinon.match.func);
+    }
+
+    function expectGetMetaPairNotCalled() {
+      expect(mockUserApiClient.getMetaPair).to.not.have.been.called;
+    }
+
+    function expectGetMetaPairForAlpha() {
+      expect(mockUserApiClient.getMetaPair).to.have.been.calledOnce;
+      expect(mockUserApiClient.getMetaPair.firstCall).to.have.been.calledWithExactly(alphaUser.userid, sinon.match.func);
+    }
+
+    function expectGetMetaPairForAlphaAndBravo() {
+      expectGetUserInfoForAlphaAndBravo();
+      expect(mockUserApiClient.getMetaPair).to.have.been.calledTwice;
+      expect(mockUserApiClient.getMetaPair.firstCall).to.have.been.calledWithExactly(alphaUser.userid, sinon.match.func);
+      expect(mockUserApiClient.getMetaPair.secondCall).to.have.been.calledWithExactly(bravoUser.userid, sinon.match.func);
+    }
+
+    function expectGetDocNotCalled() {
+      expect(mockCrudHandler.getDoc).to.not.have.been.called;
+    }
+
+    function expectGetDocForAlpha() {
+      expect(mockCrudHandler.getDoc).to.have.been.calledOnce;
+      expect(mockCrudHandler.getDoc).to.have.been.calledWithExactly(alphaMetaPair, sinon.match.func);
+    }
+
+    function expectGetDocForBravo() {
+      expect(mockCrudHandler.getDoc).to.have.been.calledOnce;
+      expect(mockCrudHandler.getDoc).to.have.been.calledWithExactly(bravoMetaPair, sinon.match.func);
+    }
+
+    function expectGetDocForAlphaAndBravo() {
+      expectGetMetaPairForAlphaAndBravo();
+      expect(mockCrudHandler.getDoc).to.have.been.calledTwice;
+      expect(mockCrudHandler.getDoc.firstCall).to.have.been.calledWithExactly(alphaMetaPair, sinon.match.func);
+      expect(mockCrudHandler.getDoc.secondCall).to.have.been.calledWithExactly(bravoMetaPair, sinon.match.func);
+    }
+
+    it('returns 401 without session token', function(done) {
+      sessionTokenId = null;
+      expectUnauthorizedTest(targetUrl,
+          [expectBodyWithEmptyObject, expectUserInGroupNotCalled, expectGroupsForUserNotCalled], done);
+    });
+
+    describe('with token data', function() {
+      it('returns 401 with bogus session token', function(done) {
+        sessionTokenId = 'bogus';
+        expectUnauthorizedTest(targetUrl,
+            [expectBodyWithEmptyObject, expectUserInGroupNotCalled, expectGroupsForUserNotCalled], done);
+      });
+
+      it('returns 401 for a session token that is not the user, nor server, nor custodian, but is a shared user', function(done) {
+        sessionTokenId = viewerToken.userid;
+        expectUnauthorizedTest(targetUrl,
+            [expectUserInGroup, expectGroupsForUserNotCalled], done);
+      });
+
+      it('returns success and two shared users with no query, as user', function(done) {
+        expectSuccessfulTest(targetUrl,
+            [expectBodyWithAlphaAndBravo, expectUserInGroupNotCalled, expectGetDocForAlphaAndBravo], done);
+      });
+
+      it('returns success and two shared users with no query, as server', function(done) {
+        sessionTokenId = serverToken.userid;
+        expectSuccessfulTest(targetUrl,
+            [expectBodyWithAlphaAndBravo, expectUserInGroupNotCalled, expectGetDocForAlphaAndBravo], done);
+      });
+
+      it('returns success and two shared users with no query, as custodian', function(done) {
+        sessionTokenId = custodianToken.userid;
+        expectSuccessfulTest(targetUrl,
+            [expectBodyWithAlphaAndBravo, expectUserInGroup, expectGetDocForAlphaAndBravo], done);
+      });
+
+      it('returns failure with empty body due to error returned by userInGroup', function(done) {
+        sessionTokenId = custodianToken.userid;
+        userInGroupStub.withArgs(custodianToken.userid, targetUser.userid).callsArgWith(2, {statusCode: 503, message: 'ERROR'}, null);
+        test(targetUrl, 503, [expectBodyWithEmptyObject], done);
+      });
+
+      describe('with permissions data', function() {
+        it('returns failure with empty body due to error returned by groupsForUser', function(done) {
+          groupsForUserStub.withArgs(targetUser.userid).callsArgWith(1, {statusCode: 503, message: 'ERROR'}, null);
+          test(targetUrl, 503, [expectBodyWithEmptyObject], done);
+        });
+
+        it('returns success and two shared users with query for a specific permission', function(done) {
+          expectSuccessfulTest(targetUrl + '?permissions=view',
+              [expectBodyWithAlphaAndBravo, expectGetDocForAlphaAndBravo], done);
+        });
+
+        it('returns success and one shared user with query for a specific permission', function(done) {
+          expectSuccessfulTest(targetUrl + '?permissions=upload',
+              [expectBodyWithAlpha, expectGroupsForUser, expectGetUserInfoForAlpha, expectGetMetaPairForAlpha, expectGetDocForAlpha], done);
+        });
+
+        it('returns success and one shared user with query for multiple specific permissions', function(done) {
+          expectSuccessfulTest(targetUrl + '?permissions=upload,view',
+              [expectBodyWithAlpha, expectGroupsForUser, expectGetUserInfoForAlpha, expectGetMetaPairForAlpha, expectGetDocForAlpha], done);
+        });
+
+        it('returns success and one shared user with query for multiple specific permissions', function(done) {
+          expectSuccessfulTest(targetUrl + '?permissions=upload,,,view',
+              [expectBodyWithAlpha, expectGroupsForUser, expectGetUserInfoForAlpha, expectGetMetaPairForAlpha, expectGetDocForAlpha], done);
+        });
+
+        it('returns success and no shared users with query for an unknown permission', function(done) {
+          expectSuccessfulTest(targetUrl + '?permissions=unknown',
+              [expectBodyWithEmptyArray, expectGroupsForUser, expectGetUserInfoNotCalled, expectGetMetaPairNotCalled], done);
+        });
+
+        it('returns success and no shared users with query for multiple unknown permissions', function(done) {
+          expectSuccessfulTest(targetUrl + '?permissions=unknown,,,view',
+              [expectBodyWithEmptyArray, expectGroupsForUser, expectGetUserInfoNotCalled, expectGetMetaPairNotCalled], done);
+        });
+
+        it('returns success and one shared user with query on multiple parameters that matches one (other missing permissions)', function(done) {
+          targetUser.groups[bravoUser.userid] = null;
+          expectSuccessfulTest(targetUrl + '?permissions=view&email=TIDEPOOL.ORG&termsAccepted=20&name=A&birthday=-30&diagnosisDate=-31',
+              [expectBodyWithAlpha, expectGroupsForUser, expectGetUserInfoForAlpha, expectGetMetaPairForAlpha, expectGetDocForAlpha], done);
+        });
+
+        describe('with user data', function() {
+          it('returns failure with empty body due to error returned by getUserInfo', function(done) {
+            getUserInfoStub.withArgs(alphaUser.userid).callsArgWith(1, {statusCode: 503, message: 'ERROR'}, null);
+            test(targetUrl, 503, [expectBodyWithEmptyObject], done);
+          });
+
+          it('returns failure with empty body due to null user returned by getUserInfo', function(done) {
+            getUserInfoStub.withArgs(alphaUser.userid).callsArgWith(1, null, null);
+            test(targetUrl, 500, [expectBodyWithEmptyObject], done);
+          });
+
+          it('returns success and two shared users with query for a case-insensitive partial email that matches both', function(done) {
+            expectSuccessfulTest(targetUrl + '?email=TIDEPOOL.ORG',
+                [expectBodyWithAlphaAndBravo, expectGetDocForAlphaAndBravo], done);
+          });
+
+          it('returns success and one shared user with query for a specific, case-insensitive email that matches one', function(done) {
+            expectSuccessfulTest(targetUrl + '?email=ALPHA@TIDEPOOL.org',
+                [expectBodyWithAlpha, expectGetUserInfoForAlphaAndBravo, expectGetMetaPairForAlpha, expectGetDocForAlpha], done);
+          });
+
+          it('returns success and no shared users with query for an unknown email that matches none', function(done) {
+            expectSuccessfulTest(targetUrl + '?email=unknown.org',
+                [expectBodyWithEmptyArray, expectGetUserInfoForAlphaAndBravo, expectGetMetaPairNotCalled], done);
+          });
+
+          it('returns success and one shared user with query for email verified (TruE)', function(done) {
+            expectSuccessfulTest(targetUrl + '?emailVerified=TruE',
+                [expectBodyWithAlpha, expectGetUserInfoForAlphaAndBravo, expectGetMetaPairForAlpha, expectGetDocForAlpha], done);
+          });
+
+          it('returns success and one shared user with query for email verified (YeS)', function(done) {
+            expectSuccessfulTest(targetUrl + '?emailVerified=YeS',
+                [expectBodyWithAlpha, expectGetUserInfoForAlphaAndBravo, expectGetMetaPairForAlpha, expectGetDocForAlpha], done);
+          });
+
+          it('returns success and one shared user with query for email verified (Y)', function(done) {
+            expectSuccessfulTest(targetUrl + '?emailVerified=Y',
+                [expectBodyWithAlpha, expectGetUserInfoForAlphaAndBravo, expectGetMetaPairForAlpha, expectGetDocForAlpha], done);
+          });
+
+          it('returns success and one shared user with query for email verified (1)', function(done) {
+            expectSuccessfulTest(targetUrl + '?emailVerified=1',
+                [expectBodyWithAlpha, expectGetUserInfoForAlphaAndBravo, expectGetMetaPairForAlpha, expectGetDocForAlpha], done);
+          });
+
+          it('returns success and one shared user with query for email not verified (FalsE)', function(done) {
+            expectSuccessfulTest(targetUrl + '?emailVerified=FalsE',
+                [expectBodyWithBravo, expectGetUserInfoForAlphaAndBravo, expectGetDocForBravo], done);
+          });
+
+          it('returns success and one shared user with query for email not verified (0)', function(done) {
+            expectSuccessfulTest(targetUrl + '?emailVerified=0',
+                [expectBodyWithBravo, expectGetUserInfoForAlphaAndBravo, expectGetDocForBravo], done);
+          });
+
+          it('returns success and one shared user with query for email not verified (AnythinG)', function(done) {
+            expectSuccessfulTest(targetUrl + '?emailVerified=AnythinG',
+                [expectBodyWithBravo, expectGetUserInfoForAlphaAndBravo, expectGetDocForBravo], done);
+          });
+
+          it('returns success and two shared users with query for a partial terms accepted that matches both', function(done) {
+            expectSuccessfulTest(targetUrl + '?termsAccepted=20',
+                [expectBodyWithAlphaAndBravo, expectGetDocForAlphaAndBravo], done);
+          });
+
+          it('returns success and two shared users with query for a partial terms accepted that matches both (case insensitive)', function(done) {
+            expectSuccessfulTest(targetUrl + '?termsAccepted=t',
+                [expectBodyWithAlphaAndBravo, expectGetDocForAlphaAndBravo], done);
+          });
+
+          it('returns success and one shared user with query for a partial terms accepted that matches one', function(done) {
+            expectSuccessfulTest(targetUrl + '?termsAccepted=2016',
+                [expectBodyWithAlpha, expectGetUserInfoForAlphaAndBravo, expectGetMetaPairForAlpha, expectGetDocForAlpha], done);
+          });
+
+          it('returns success and one shared user with query for a specific terms accepted', function(done) {
+            expectSuccessfulTest(targetUrl + '?termsAccepted=2016-01-01T12:00:00-07:00',
+                [expectBodyWithAlpha, expectGetUserInfoForAlphaAndBravo, expectGetMetaPairForAlpha, expectGetDocForAlpha], done);
+          });
+
+          it('returns success and no shared users with query for a terms accepted that does not match', function(done) {
+            expectSuccessfulTest(targetUrl + '?termsAccepted=9999',
+                [expectBodyWithEmptyArray, expectGetUserInfoForAlphaAndBravo, expectGetDocNotCalled], done);
+          });
+
+          it('returns success and one shared user with query on multiple parameters that matches one (other missing username)', function(done) {
+            bravoUser.username = null;
+            expectSuccessfulTest(targetUrl + '?permissions=view&email=TIDEPOOL.ORG&termsAccepted=20&name=A&birthday=-30&diagnosisDate=-31',
+                [expectBodyWithAlpha, expectGetUserInfoForAlphaAndBravo, expectGetMetaPairForAlpha, expectGetDocForAlpha], done);
+          });
+
+          it('returns success and one shared user with query on multiple parameters that matches one (other missing termsAccepted)', function(done) {
+            bravoUser.termsAccepted = null;
+            expectSuccessfulTest(targetUrl + '?permissions=view&email=TIDEPOOL.ORG&termsAccepted=20&name=A&birthday=-30&diagnosisDate=-31',
+                [expectBodyWithAlpha, expectGetUserInfoForAlphaAndBravo, expectGetMetaPairForAlpha, expectGetDocForAlpha], done);
+          });
+
+          describe('with profile data', function() {
+            it('returns failure with empty body due to error returned by getMetaPair', function(done) {
+              getMetaPairStub.withArgs(alphaUser.userid).callsArgWith(1, {statusCode: 503, message: 'ERROR'}, null);
+              test(targetUrl, 503, [expectBodyWithEmptyObject], done);
+            });
+
+            it('returns failure with empty body due to error returned by getDoc', function(done) {
+              getDocStub.withArgs(alphaMetaPair).callsArgWith(1, {statusCode: 503, message: 'ERROR'}, null);
+              test(targetUrl, 503, [expectBodyWithEmptyObject], done);
+            });
+
+            it('returns success and one shared user due to not found error returned by getMetaPair for one user', function(done) {
+              getMetaPairStub.withArgs(bravoUser.userid).callsArgWith(1, {statusCode: 404}, null);
+              expectSuccessfulTest(targetUrl + '?name=A',
+                  [expectBodyWithAlpha, expectGetMetaPairForAlphaAndBravo, expectGetDocForAlpha], done);
+            });
+
+            it('returns success and one shared user due to not found error returned by getDoc for one user', function(done) {
+              getDocStub.withArgs(bravoMetaPair).callsArgWith(1, {statusCode: 404}, null);
+              expectSuccessfulTest(targetUrl + '?name=A',
+                  [expectBodyWithAlpha, expectGetDocForAlphaAndBravo], done);
+            });
+
+            it('returns success and two shared users with query for a partial name that matches both', function(done) {
+              expectSuccessfulTest(targetUrl + '?name=A',
+                  [expectBodyWithAlphaAndBravo, expectGetDocForAlphaAndBravo], done);
+            });
+
+            it('returns success and one shared user with query for a partial name that matches one', function(done) {
+              expectSuccessfulTest(targetUrl + '?name=LpH',
+                  [expectBodyWithAlpha, expectGetDocForAlphaAndBravo], done);
+            });
+
+            it('returns success and no shared users with query for a partial name that matches none', function(done) {
+              expectSuccessfulTest(targetUrl + '?name=AbC',
+                  [expectBodyWithEmptyArray, expectGetDocForAlphaAndBravo], done);
+            });
+
+            it('returns success and two shared users with query for a partial birthday that matches both', function(done) {
+              expectSuccessfulTest(targetUrl + '?birthday=-30',
+                  [expectBodyWithAlphaAndBravo, expectGetDocForAlphaAndBravo], done);
+            });
+
+            it('returns success and one shared user with query for a partial birthday that matches one', function(done) {
+              expectSuccessfulTest(targetUrl + '?birthday=-11-',
+                  [expectBodyWithAlpha, expectGetDocForAlphaAndBravo], done);
+            });
+
+            it('returns success and no shared users with query for a partial birthday that matches none', function(done) {
+              expectSuccessfulTest(targetUrl + '?birthday=1900-',
+                  [expectBodyWithEmptyArray, expectGetDocForAlphaAndBravo], done);
+            });
+
+            it('returns success and two shared users with query for a partial diagnosis date that matches both', function(done) {
+              expectSuccessfulTest(targetUrl + '?diagnosisDate=-31',
+                  [expectBodyWithAlphaAndBravo, expectGetDocForAlphaAndBravo], done);
+            });
+
+            it('returns success and one shared user with query for a partial diagnosis date that matches one', function(done) {
+              expectSuccessfulTest(targetUrl + '?diagnosisDate=-12-',
+                  [expectBodyWithAlpha, expectGetDocForAlphaAndBravo], done);
+            });
+
+            it('returns success and no shared users with query for a partial diagnosis date that matches none', function(done) {
+              expectSuccessfulTest(targetUrl + '?diagnosisDate=1900-',
+                  [expectBodyWithEmptyArray, expectGetDocForAlphaAndBravo], done);
+            });
+
+            it('returns success and two shared users with query on multiple parameters that matches both', function(done) {
+              expectSuccessfulTest(targetUrl + '?permissions=view&email=TIDEPOOL.ORG&termsAccepted=20&name=A&birthday=-30&diagnosisDate=-31',
+                  [expectBodyWithAlphaAndBravo, expectGetDocForAlphaAndBravo], done);
+            });
+
+            it('returns success and one shared user with query on multiple parameters that matches one (other missing fullName)', function(done) {
+              bravoDoc.detail.profile.fullName = null;
+              expectSuccessfulTest(targetUrl + '?permissions=view&email=TIDEPOOL.ORG&termsAccepted=20&name=A&birthday=-30&diagnosisDate=-31',
+                  [expectBodyWithAlpha, expectGetDocForAlphaAndBravo], done);
+            });
+
+            it('returns success and one shared user with query on multiple parameters that matches one (other missing patient)', function(done) {
+              bravoDoc.detail.profile.patient = null;
+              expectSuccessfulTest(targetUrl + '?permissions=view&email=TIDEPOOL.ORG&termsAccepted=20&name=A&birthday=-30&diagnosisDate=-31',
+                  [expectBodyWithAlpha, expectGetDocForAlphaAndBravo], done);
+            });
+
+            it('returns success and one shared user with query on multiple parameters that matches one (other missing birthday)', function(done) {
+              bravoDoc.detail.profile.patient.birthday = null;
+              expectSuccessfulTest(targetUrl + '?permissions=view&email=TIDEPOOL.ORG&termsAccepted=20&name=A&birthday=-30&diagnosisDate=-31',
+                  [expectBodyWithAlpha, expectGetDocForAlphaAndBravo], done);
+            });
+
+            it('returns success and one shared user with query on multiple parameters that matches one (other missing diagnosis date)', function(done) {
+              bravoDoc.detail.profile.patient.diagnosisDate = null;
+              expectSuccessfulTest(targetUrl + '?permissions=view&email=TIDEPOOL.ORG&termsAccepted=20&name=A&birthday=-30&diagnosisDate=-31',
+                  [expectBodyWithAlpha, expectGetDocForAlphaAndBravo], done);
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/testSeagullServiceUsers.js
+++ b/test/testSeagullServiceUsers.js
@@ -364,6 +364,32 @@ describe('seagull/users', function () {
               [expectBodyWithEmptyArray, expectUsersInGroup, expectGetUserInfoNotCalled, expectGetMetaPairNotCalled], done);
         });
 
+        it('returns failure with empty body due to trustor permissions of any and another', function(done) {
+          test(targetUrl + '?trustorPermissions=view,any', 400, [], done);
+        });
+
+        it('returns failure with empty body due to trustor permissions of none and another', function(done) {
+          test(targetUrl + '?trustorPermissions=view,none', 400, [], done);
+        });
+
+        it('returns failure with empty body due to trustor permissions of any and none', function(done) {
+          test(targetUrl + '?trustorPermissions=none,any', 400, [], done);
+        });
+
+        it('returns success and one shared user with query for trustor permissions of any', function(done) {
+          delete targetUser.groups[bravoUser.userid];
+          expectSuccessfulTest(targetUrl + '?trustorPermissions=any',
+              [expectBodyWithAlpha, expectUsersInGroup, expectGetUserInfoForAlpha, expectGetMetaPairForAlpha, expectGetDocForAlpha], done);
+        });
+
+        it('returns success and one shared user with query for trustor permissions of none', function(done) {
+          delete targetUser.groups[alphaUser.userid];
+          delete alphaFinal.trustorPermissions;
+          delete alphaFinal.profile.patient;
+          expectSuccessfulTest(targetUrl + '?trustorPermissions=none',
+              [expectBodyWithAlpha, expectUsersInGroup, expectGetUserInfoForAlpha, expectGetMetaPairForAlpha, expectGetDocForAlpha], done);
+        });
+
         it('returns success and one shared user with query on multiple parameters that matches one (other missing permissions)', function(done) {
           targetUser.groups[bravoUser.userid] = null;
           expectSuccessfulTest(targetUrl + '?trustorPermissions=view&email=TIDEPOOL.ORG&termsAccepted=20&name=A&birthday=-30&diagnosisDate=-31',
@@ -404,6 +430,31 @@ describe('seagull/users', function () {
           it('returns success and no shared users with query for multiple unknown trustee permissions', function(done) {
             expectSuccessfulTest(targetUrl + '?trusteePermissions=unknown,,,view',
                 [expectBodyWithEmptyArray, expectUsersInGroup, expectGetUserInfoNotCalled, expectGetMetaPairNotCalled], done);
+          });
+
+          it('returns failure with empty body due to trustee permissions of any and another', function(done) {
+            test(targetUrl + '?trusteePermissions=view,any', 400, [], done);
+          });
+
+          it('returns failure with empty body due to trustee permissions of none and another', function(done) {
+            test(targetUrl + '?trusteePermissions=view,none', 400, [], done);
+          });
+
+          it('returns failure with empty body due to trustee permissions of any and none', function(done) {
+            test(targetUrl + '?trusteePermissions=none,any', 400, [], done);
+          });
+
+          it('returns success and one shared user with query for trustee permissions of any', function(done) {
+            delete targetUser.users[bravoUser.userid];
+            expectSuccessfulTest(targetUrl + '?trusteePermissions=any',
+                [expectBodyWithAlpha, expectUsersInGroup, expectGetUserInfoForAlpha, expectGetMetaPairForAlpha, expectGetDocForAlpha], done);
+          });
+
+          it('returns success and one shared user with query for trustee permissions of none', function(done) {
+            delete targetUser.users[alphaUser.userid];
+            delete alphaFinal.trusteePermissions;
+            expectSuccessfulTest(targetUrl + '?trusteePermissions=none',
+                [expectBodyWithAlpha, expectUsersInGroup, expectGetUserInfoForAlpha, expectGetMetaPairForAlpha, expectGetDocForAlpha], done);
           });
 
           it('returns success and one shared user with query on multiple parameters that matches one (other missing permissions)', function(done) {


### PR DESCRIPTION
@jh-bate The first commit just fixes up `statuscode` to `statusCode` to be consistent across repos (and to make the new code use the same).  The second commit is the new API and tests.