### PR TITLE
Unified users add settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ pids
 logs
 results
 config
+build
 
 npm-debug.log
 node_modules

--- a/lib/routes/seagullApi.js
+++ b/lib/routes/seagullApi.js
@@ -285,8 +285,20 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
 
                 if (_.isEmpty(user.trustorPermissions)) {
                   delete user.profile.patient;
+                } else {
+                  if (user.trustorPermissions.view || user.trustorPermissions.upload) {
+                    var settings = _.result(document, 'detail.settings');
+                    if (!_.isEmpty(settings)) {
+                      user.settings = settings;
+                    }
+                  }
+                  if (user.trustorPermissions.custodian) {
+                    var preferences = _.result(document, 'detail.preferences');
+                    if (!_.isEmpty(preferences)) {
+                      user.preferences = preferences;
+                    }
+                  }
                 }
-
                 return callback(null, userMatchingQuery(user, query));
               });
             });

--- a/lib/routes/seagullApi.js
+++ b/lib/routes/seagullApi.js
@@ -286,7 +286,10 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
                 if (_.isEmpty(user.trustorPermissions)) {
                   delete user.profile.patient;
                 } else {
-                  if (user.trustorPermissions.view || user.trustorPermissions.upload) {
+                  if (
+                    user.trustorPermissions.custodian ||
+                    user.trustorPermissions.view ||
+                    user.trustorPermissions.upload) {
                     var settings = _.result(document, 'detail.settings');
                     if (!_.isEmpty(settings)) {
                       user.settings = settings;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seagull",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "API for managing user metadata.",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
@darinkrauss based on our initial discussion I believe this logic is now correct. I have done some local testing and can see the settings being exposed. Keen to do further verification once you have had a look at this initial PR though 

```
{ emailVerified: true,
  emails: [ 'jamie+pwd3@tidepool.org' ],
  passwordExists: true,
  termsAccepted: '2017-04-12T16:36:14+12:00',
  userid: '17e77a2183',
  username: 'jamie+pwd3@tidepool.org',
  trustorPermissions: { note: {}, upload: {}, view: {} },
  profile:
   { fullName: 'Local PWD3',
     patient: { birthday: '1999-06-14', diagnosisDate: '2010-05-10' } },
  settings: { bgTarget: { high: 120, low: 70 }, units: { bg: 'mg/dL' } } }
```
