### PR TITLE
 Only return metadata when the requesting user has trustor permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,14 @@ FROM node:6.10.3-alpine
 
 WORKDIR /app
 
-COPY . .
+COPY package.json .
 
 RUN apk add --no-cache --virtual .build-dependencies git && \
     sed -i -e 's/"mongojs": "0.18.2"/"mongojs": "2.4.0"/g' package.json && \
     yarn install && \
     apk del .build-dependencies
+
+COPY . .
 
 USER node
 

--- a/lib/routes/seagullApi.js
+++ b/lib/routes/seagullApi.js
@@ -339,7 +339,7 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
         return next();
       }
 
-      let hasTrustorPermissions = false;
+      var hasTrustorPermissions = false;
 
       gatekeeperClient.groupsForUser(req._tokendata.userid, function(error, trustorUserPermissions) {
         if (error) {

--- a/lib/routes/seagullApi.js
+++ b/lib/routes/seagullApi.js
@@ -339,19 +339,42 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
         return next();
       }
 
-      crudHandler.getDoc(req.params.userid, function (err, result) {
-        if (err) {
-          log.error(err, 'Error reading metadata doc');
-          res.send(err.statusCode);
-        } else {
-          var retVal = result.detail[collection];
-          if (retVal == null) {
-            res.send(404);
-          } else {
-            res.send(200, retVal);
-          }
+      let hasTrustorPermissions = false;
+
+      gatekeeperClient.groupsForUser(req._tokendata.userid, function(error, trustorUserPermissions) {
+        if (error) {
+          log.error(error, 'Error getting groups for target user id', req._tokendata.userid);
+          res.send(error.statusCode || 500);
+          return next(false);
         }
-        return next();
+
+        if (trustorUserPermissions && !_.isUndefined(trustorUserPermissions[req.params.userid])) {
+          hasTrustorPermissions = true;
+        }
+
+        if (hasTrustorPermissions || collection === 'profile') {
+          crudHandler.getDoc(req.params.userid, function (err, result) {
+            if (err) {
+              log.error(err, 'Error reading metadata doc');
+              res.send(err.statusCode);
+            } else {
+              var retVal = result.detail[collection];
+              if (retVal == null) {
+                res.send(404);
+              } else {
+                if (collection === 'profile' && !hasTrustorPermissions) {
+                  res.send(200, {fullName: retVal.fullName});
+                } else {
+                  res.send(200, retVal);
+                }
+              }
+            }
+            return next();
+          });
+        } else {
+          res.send(401);
+          return next();
+        }
       });
     },
 

--- a/lib/routes/seagullApi.js
+++ b/lib/routes/seagullApi.js
@@ -372,7 +372,7 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
             return next();
           });
         } else {
-          res.send(401);
+          res.send(401, 'Unauthorized');
           return next();
         }
       });

--- a/lib/routes/seagullApi.js
+++ b/lib/routes/seagullApi.js
@@ -343,7 +343,7 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
 
       gatekeeperClient.groupsForUser(req._tokendata.userid, function(error, trustorUserPermissions) {
         if (error) {
-          log.error(error, 'Error getting groups for target user id', req._tokendata.userid);
+          log.error(error, 'Error getting groups for authenticated user id', req._tokendata.userid);
           res.send(error.statusCode || 500);
           return next(false);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seagull",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "API for managing user metadata.",
   "main": "lib/index.js",
   "directories": {

--- a/test/testSeagullService.js
+++ b/test/testSeagullService.js
@@ -39,7 +39,7 @@ var env = {
 };
 
 var userApiClient = mockableObject.make('checkToken', 'getAnonymousPair');
-var gatekeeperClient = mockableObject.make('userInGroup');
+var gatekeeperClient = mockableObject.make('userInGroup', 'groupsForUser');
 var metrics = mockableObject.make('postServer', 'postThisUser', 'postWithUser');
 
 var dbmongo = require('../lib/mongoCrudHandler.js')(env);

--- a/test/testSeagullService.js
+++ b/test/testSeagullService.js
@@ -197,6 +197,7 @@ describe('seagull', function () {
 
   describe('/:userid/:collection', function () {
     var metatest1 = {
+      fullName: 'Billy McBillface',
       name: 'Testy',
       bio: 'Awesome is my game.'
     };
@@ -204,10 +205,16 @@ describe('seagull', function () {
       shortname: 'Boo',
       bio: 'Haunting is my game.'
     };
+    var settingstest = {
+      siteChangeSource: 'cannulaPrime',
+      bgTarget: {'high': 180, 'low': 72},
+      units: {'bg': 'mg/dL'}
+    };
     var sally = { userid: 'sally', isserver: true };
 
     it('GET should return 404 because it doesn\'t exist yet (server)', function (done) {
       setupToken(sally);
+      sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {'sally': {root: {}}});
       supertest
         .get('/billy/profile')
         .set(sessionTokenHeader, 'howdy')
@@ -222,6 +229,7 @@ describe('seagull', function () {
 
     it('GET should return 404 because it doesn\'t exist yet (same user id)', function (done) {
       setupToken();
+      sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {'sally': {root: {}}});
       supertest
         .get('/billy/profile')
         .set(sessionTokenHeader, 'howdy')
@@ -236,6 +244,7 @@ describe('seagull', function () {
 
     it('GET should return 404 because it doesn\'t exist yet (with different user ids; with member permissions)', function (done) {
       setupToken();
+      sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {'sally': {root: {}}});
       var userInGroupStub = sinon.stub(gatekeeperClient, 'userInGroup');
       userInGroupStub.callsArgWith(2, null, {'view': {}});
       supertest
@@ -354,8 +363,25 @@ describe('seagull', function () {
         });
     });
 
-    it('GET should return 200 and stored result on success', function (done) {
+    it('GET profile should return 200 and only fullName if not a trustor', function (done) {
       setupToken();
+      sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {'sally': {root: {}}});
+      supertest
+        .get('/billy/profile')
+        .set(sessionTokenHeader, 'howdy')
+        .expect(200)
+        .end(
+        function (err, res) {
+          expect(err).to.not.exist;
+          expect(res.body).deep.equals({"fullName": "Billy McBillface"});
+          expectToken('howdy');
+          done();
+        });
+    });
+
+    it('GET profile should return 200 and full stored result if a trustor', function (done) {
+      setupToken();
+      sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {'sally': {root: {}}, 'billy': {view: {}}});
       supertest
         .get('/billy/profile')
         .set(sessionTokenHeader, 'howdy')
@@ -364,6 +390,54 @@ describe('seagull', function () {
         function (err, res) {
           expect(err).to.not.exist;
           expect(res.body).deep.equals(metatest1);
+          expectToken('howdy');
+          done();
+        });
+    });
+
+    it('PUT non-profile should return a 200 on success (server)', function (done) {
+      setupToken();
+      supertest
+        .post('/billy/settings')
+        .send(settingstest)
+        .set(sessionTokenHeader, 'howdy')
+        .expect(200)
+        .end(
+        function (err, res) {
+          expect(err).to.not.exist;
+          expect(res.body).deep.equals(settingstest);
+          expectToken('howdy');
+          done();
+        });
+    });
+
+    it('GET non-profile should return 401 if not a trustor', function (done) {
+      setupToken(sally);
+      sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {'sally': {root: {}}});
+      supertest
+        .get('/billy/settings')
+        .set(sessionTokenHeader, 'howdy')
+        .expect(401)
+        .end(
+        function (err, res) {
+          expect(err).to.not.exist;
+          expect(res.body).deep.equals('Unauthorized');
+          expectToken('howdy');
+          done();
+        });
+    });
+
+    it('GET non-profile should return 200 and full stored result if a trustor', function (done) {
+      setupToken(sally);
+      sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {'sally': {root: {}}, 'billy': {view: {}}});
+      supertest
+        .get('/billy/settings')
+        .set(sessionTokenHeader, 'howdy')
+        .expect(200)
+        .end(
+        function (err, res) {
+          expect(err).to.not.exist;
+          expect(res.body).deep.equals(settingstest);
           expectToken('howdy');
           done();
         });
@@ -457,6 +531,7 @@ describe('seagull', function () {
 
     it('GET should return 200 and updated result on success', function (done) {
       setupToken();
+      sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {'billy': {root: {}}});
       supertest
         .get('/billy/profile')
         .set(sessionTokenHeader, 'howdy')


### PR DESCRIPTION
Seagull was returning the diagnosis date & birthday of the person
data was shared *with*. This was leaking information which wasn't
explicitly shared.
The only exception is that `fullName` is still returned, as this is used
by Tidepool for Web to render the name of whom you have shared data with
on the "Share" page.
* Fixes https://trello.com/c/oR8PydXP