### PR TITLE
Custodial account claim regression fix

### DIFF
--- a/lib/routes/seagullApi.js
+++ b/lib/routes/seagullApi.js
@@ -348,7 +348,10 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
           return next(false);
         }
 
-        if (trustorUserPermissions && !_.isUndefined(trustorUserPermissions[req.params.userid])) {
+        // Check to see if the user has trustor permissions for the requested user ID
+        // or `hydrophone` (which is listed as a trustor when claiming a VCA-created custodial account).
+        var trustorUserIds = _.keys(trustorUserPermissions);
+        if (!_.isEmpty(_.intersection(trustorUserIds, [req.params.userid, 'hydrophone']))) {
           hasTrustorPermissions = true;
         }
 

--- a/lib/routes/seagullApi.js
+++ b/lib/routes/seagullApi.js
@@ -49,6 +49,28 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
     });
   }
 
+  function getCollection(req, res, sanitize, next) {
+    crudHandler.getDoc(_.get(req, 'params.userid'), function (err, result) {
+      if (err) {
+        log.error(err, 'Error reading metadata doc');
+        res.send(err.statusCode);
+      } else {
+        var collection = _.get(req, 'params.collection');
+        var retVal = result.detail[collection];
+        if (retVal == null) {
+          res.send(404);
+        } else {
+          if (collection === 'profile' && sanitize) {
+            res.send(200, sanitizeProfile(retVal));
+          } else {
+            res.send(200, retVal);
+          }
+        }
+      }
+      return next();
+    });
+  }
+
   var ANY = ['any'];
   var NONE = ['none'];
   var TRUES = ['true', 'yes', 'y', '1'];
@@ -199,6 +221,10 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
     return _.omit(user, 'passwordExists');
   }
 
+  function sanitizeProfile(profile) {
+    return _.pick(profile, 'fullName');
+  }
+
   return {
     /** HEALTH CHECK **/
     status: function (req, res, next) {
@@ -339,7 +365,10 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
         return next();
       }
 
-      var hasTrustorPermissions = false;
+      if (req._tokendata.isserver) {
+        var sanitize = false;
+        return getCollection(req, res, sanitize, next);
+      }
 
       gatekeeperClient.groupsForUser(req._tokendata.userid, function(error, trustorUserPermissions) {
         if (error) {
@@ -349,31 +378,11 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
         }
 
         // Check to see if the user has trustor permissions for the requested user ID
-        // or `hydrophone` (which is listed as a trustor when claiming a VCA-created custodial account).
-        var trustorUserIds = _.keys(trustorUserPermissions);
-        if (!_.isEmpty(_.intersection(trustorUserIds, [req.params.userid, 'hydrophone']))) {
-          hasTrustorPermissions = true;
-        }
+        var hasTrustorPermissions = _.has(trustorUserPermissions, req.params.userid);
 
         if (hasTrustorPermissions || collection === 'profile') {
-          crudHandler.getDoc(req.params.userid, function (err, result) {
-            if (err) {
-              log.error(err, 'Error reading metadata doc');
-              res.send(err.statusCode);
-            } else {
-              var retVal = result.detail[collection];
-              if (retVal == null) {
-                res.send(404);
-              } else {
-                if (collection === 'profile' && !hasTrustorPermissions) {
-                  res.send(200, {fullName: retVal.fullName});
-                } else {
-                  res.send(200, retVal);
-                }
-              }
-            }
-            return next();
-          });
+          var sanitize = !hasTrustorPermissions;
+          return getCollection(req, res, sanitize, next);
         } else {
           res.send(401, 'Unauthorized');
           return next();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seagull",
-  "version": "0.7.1-custodial-signup-fix.2",
+  "version": "0.7.1",
   "description": "API for managing user metadata.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seagull",
-  "version": "0.7.0",
+  "version": "0.7.1-custodial-signup-fix.1",
   "description": "API for managing user metadata.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seagull",
-  "version": "0.7.1-custodial-signup-fix.1",
+  "version": "0.7.1-custodial-signup-fix.2",
   "description": "API for managing user metadata.",
   "main": "lib/index.js",
   "directories": {

--- a/test/testSeagullService.js
+++ b/test/testSeagullService.js
@@ -395,6 +395,22 @@ describe('seagull', function () {
         });
     });
 
+    it('GET profile should return 200 and full stored result if trustor is `hydrophone`', function (done) {
+      setupToken();
+      sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {hydrophone: { root: {}}});
+      supertest
+        .get('/billy/profile')
+        .set(sessionTokenHeader, 'howdy')
+        .expect(200)
+        .end(
+        function (err, res) {
+          expect(err).to.not.exist;
+          expect(res.body).deep.equals(metatest1);
+          expectToken('howdy');
+          done();
+        });
+    });
+
     it('PUT non-profile should return a 200 on success (server)', function (done) {
       setupToken();
       supertest

--- a/test/testSeagullService.js
+++ b/test/testSeagullService.js
@@ -395,9 +395,8 @@ describe('seagull', function () {
         });
     });
 
-    it('GET profile should return 200 and full stored result if trustor is `hydrophone`', function (done) {
-      setupToken();
-      sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {hydrophone: { root: {}}});
+    it('GET profile should return 200 and full stored result if request is from the server', function (done) {
+      setupToken(sally);
       supertest
         .get('/billy/profile')
         .set(sessionTokenHeader, 'howdy')
@@ -412,7 +411,7 @@ describe('seagull', function () {
     });
 
     it('PUT non-profile should return a 200 on success (server)', function (done) {
-      setupToken();
+      setupToken(sally);
       supertest
         .post('/billy/settings')
         .send(settingstest)
@@ -428,7 +427,7 @@ describe('seagull', function () {
     });
 
     it('GET non-profile should return 401 if not a trustor', function (done) {
-      setupToken(sally);
+      setupToken();
       sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {'sally': {root: {}}});
       supertest
         .get('/billy/settings')
@@ -444,8 +443,23 @@ describe('seagull', function () {
     });
 
     it('GET non-profile should return 200 and full stored result if a trustor', function (done) {
-      setupToken(sally);
+      setupToken();
       sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {'sally': {root: {}}, 'billy': {view: {}}});
+      supertest
+        .get('/billy/settings')
+        .set(sessionTokenHeader, 'howdy')
+        .expect(200)
+        .end(
+        function (err, res) {
+          expect(err).to.not.exist;
+          expect(res.body).deep.equals(settingstest);
+          expectToken('howdy');
+          done();
+        });
+    });
+
+    it('GET non-profile should return 200 and full stored result if request is from the server', function (done) {
+      setupToken(sally);
       supertest
         .get('/billy/settings')
         .set(sessionTokenHeader, 'howdy')


### PR DESCRIPTION
The custodial account claim process was regressed with `v0.7.0` (see tidepool-org/seagull#34) due to the profile information being stripped, which did not allow verification of the birthdate entered upon claiming with the birthdate input by the clinician who created the account.

This PR allows the full profile to be sent through when the trustor ID listed is `hydrophone`, which seems the case for clinician-created custodial accounts.

Details on Trello: https://trello.com/c/oR8PydXP