### PR TITLE
[BACK-1745] Use mongo 4.4 for testing in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+dist: focal
 
 language: node_js
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,25 @@ cache:
   directories:
     - node_modules
 
+env:
+  global:
+  - MONGODB=4.4.1
+
 before_install:
   - if [[ `npm -v` != 6* ]]; then npm install -g npm@6; fi
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.17.3
   - export PATH="$HOME/.yarn/bin:$PATH"
+  - sudo apt-get remove -y mongodb-org mongodb-org-mongos mongodb-org-server mongodb-org-shell mongodb-org-tools
+  - wget https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-${MONGODB}.tgz -O /tmp/mongodb.tgz
+  - tar -xf /tmp/mongodb.tgz
+  - mkdir /tmp/data
+  - ${PWD}/mongodb-linux-x86_64-ubuntu2004-${MONGODB}/bin/mongod --dbpath /tmp/data --bind_ip 127.0.0.1 --logpath ${PWD}/mongod.log &> /dev/null &
+  - until nc -z localhost 27017; do echo Waiting for MongoDB; sleep 1; done
 
 install:
   - yarn install --frozen-lockfile
 
 addons:
-  apt:
-    sources:
-      - mongodb-3.2-trusty
-    packages:
-      - mongodb-org-server
   artifacts:
     s3_region: us-west-2
     paths:
@@ -33,7 +38,6 @@ addons:
 
 services:
   - docker
-  - mongodb
 
 script:
   - yarn lint


### PR DESCRIPTION
The `mongojs` package uses `mongodb: "^3.3.2" in its `package.json` (https://github.com/mongo-js/mongojs/blob/master/package.json#L31) thus it will install the latest `3.x.x` version of the driver (verified locally). I don't think upgrading mongo to 4.4 will cause any issues, but we should also run our tests in travis against the version we (will) use in production.