### PR TITLE
[BACK-1975] Fix permissions issue for custodial accounts created by the new clinics service

### DIFF
--- a/lib/routes/seagullApi.js
+++ b/lib/routes/seagullApi.js
@@ -226,6 +226,13 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
     return _.pick(profile, 'fullName');
   }
 
+  function hasReadPermissions(permissions) {
+    if (!permissions) {
+      return false;
+    }
+    return !_.isEmpty(_.keys(permissions));
+  }
+
   return {
     /*
      IMPLEMENTATIONS OF METHODS
@@ -387,18 +394,17 @@ module.exports = function (crudHandler, userApiClient, gatekeeperClient, metrics
         return getCollection(req, res, sanitize, next);
       }
 
-      gatekeeperClient.groupsForUser(req._tokendata.userid, function(error, trustorUserPermissions) {
-        if (error) {
+      // Check to see if the user has trustor permissions for the requested user ID
+      gatekeeperClient.userInGroup(req._tokendata.userid, req.params.userid, function(error, permissions){
+        if (error && error.statusCode !== 401) {
           log.error(error, 'Error getting groups for authenticated user id', req._tokendata.userid);
           res.send(error.statusCode || 500);
           return next(false);
         }
 
-        // Check to see if the user has trustor permissions for the requested user ID
-        var hasTrustorPermissions = _.has(trustorUserPermissions, req.params.userid);
-
+        const hasTrustorPermissions = !error && hasReadPermissions(permissions);
         if (hasTrustorPermissions || collection === 'profile') {
-          var sanitize = !hasTrustorPermissions;
+          const sanitize = !hasTrustorPermissions;
           return getCollection(req, res, sanitize, next);
         } else {
           res.send(401, 'Unauthorized');

--- a/test/testSeagullService.js
+++ b/test/testSeagullService.js
@@ -217,7 +217,7 @@ describe('seagull', function () {
 
     it('GET should return 404 because it doesn\'t exist yet (server)', function (done) {
       setupToken(sally);
-      sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {'sally': {root: {}}});
+      sinon.stub(gatekeeperClient, 'userInGroup').callsArgWith(2, null, {root: {}});
       supertest
         .get('/billy/profile')
         .set(sessionTokenHeader, 'howdy')
@@ -232,7 +232,7 @@ describe('seagull', function () {
 
     it('GET should return 404 because it doesn\'t exist yet (same user id)', function (done) {
       setupToken();
-      sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {'sally': {root: {}}});
+      sinon.stub(gatekeeperClient, 'userInGroup').callsArgWith(2, null, {root: {}});
       supertest
         .get('/billy/profile')
         .set(sessionTokenHeader, 'howdy')
@@ -368,7 +368,7 @@ describe('seagull', function () {
 
     it('GET profile should return 200 and only fullName if not a trustor', function (done) {
       setupToken();
-      sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {'sally': {root: {}}});
+      sinon.stub(gatekeeperClient, 'userInGroup').callsArgWith(2, null, {});
       supertest
         .get('/billy/profile')
         .set(sessionTokenHeader, 'howdy')
@@ -384,7 +384,7 @@ describe('seagull', function () {
 
     it('GET profile should return 200 and full stored result if a trustor', function (done) {
       setupToken();
-      sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {'sally': {root: {}}, 'billy': {view: {}}});
+      sinon.stub(gatekeeperClient, 'userInGroup').callsArgWith(2, null, {view: {}});
       supertest
         .get('/billy/profile')
         .set(sessionTokenHeader, 'howdy')
@@ -431,7 +431,7 @@ describe('seagull', function () {
 
     it('GET non-profile should return 401 if not a trustor', function (done) {
       setupToken();
-      sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {'sally': {root: {}}});
+      sinon.stub(gatekeeperClient, 'userInGroup').callsArgWith(2, null, {});
       supertest
         .get('/billy/settings')
         .set(sessionTokenHeader, 'howdy')
@@ -447,7 +447,7 @@ describe('seagull', function () {
 
     it('GET non-profile should return 200 and full stored result if a trustor', function (done) {
       setupToken();
-      sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {'sally': {root: {}}, 'billy': {view: {}}});
+      sinon.stub(gatekeeperClient, 'userInGroup').callsArgWith(2, null, {view: {}});
       supertest
         .get('/billy/settings')
         .set(sessionTokenHeader, 'howdy')
@@ -564,7 +564,7 @@ describe('seagull', function () {
 
     it('GET should return 200 and updated result on success', function (done) {
       setupToken();
-      sinon.stub(gatekeeperClient, 'groupsForUser').callsArgWith(1, null, {'billy': {root: {}}});
+      sinon.stub(gatekeeperClient, 'userInGroup').callsArgWith(2, null, {root: {}});
       supertest
         .get('/billy/profile')
         .set(sessionTokenHeader, 'howdy')


### PR DESCRIPTION
Gatekeeper exposes multiple endpoints for checking whether one user has permissions to access data of another user. However, only one of those endpoints `/access/:userid/:granteeid` exposes indirect permissions (i.e. `clinician <-> clinic <-> patient`). 

This PR fixes the issue which prevents clinicians from accessing the full profile objects of patients by checking permissions against the correct gatekeeper endpoint.
